### PR TITLE
first draft of namespaced resolver proposal

### DIFF
--- a/active/0000-template.md
+++ b/active/0000-template.md
@@ -1,0 +1,197 @@
+- Start Date: 2014-08-29
+- RFC PR: 
+- Ember Issue: 
+
+# Summary
+
+Allow namespaced naming convention out of the box. Allow this strategy to co-exist nicely with current flat naming convention.
+
+# Motivation
+
+Why are we doing this?  What use cases does it support? What is the expected outcome?
+
+The flat naming convention is inconvenient when: 
+
+1) Doing reflection or Meta programming on similar types of Application objects 
+2) Logically relating the Class to the coresponding file 
+
+## Examples
+
+1) Doing meta programming on a subset of Routes, such as attaching some kind of authentication/authorization strategy to a subset of Routes (f.ex Admin routes)
+
+The current flat structure requires some "heavy handed" regular expressions such as (pseudo programming):
+
+`App.keys.find /^(.*)Route/`
+
+With appropriate namespaces, could instead be simply:
+
+`App.Routes.keys`
+
+Much more logical and elegant.
+
+This would allow something like the following:
+
+Get all Routes (any key in the App.Routes)
+- List/Display them
+- Select a subset based on a regular expression
+- Do something on them, such as extending them with a specific base class
+
+2) For a route named `App.PostsRoute` it is not very logical, that it is to be found in `app\routes\posts_route.js`. It would make more sense to have the name reflect the full path of the file: `App.Routes.PostsRoute`. 
+
+Conclusion:
+The only downside I see is that this name is a bit longer than the flat one but the benefits outweigh the costs IMO. In any case it would be an opt-in. 
+
+On another note, I find the current design such as:
+
+```
+App.PostsRoute = Ember.Route.extend({
+    
+})
+```
+
+For large application it would be much more elegant/flexible to leave the Class extension until later (as per declarative or default strategy resolution).
+
+Alternative approach:
+
+```
+App.PostsRoute = {
+    ...    
+})
+```
+
+On application load:
+
+Find all Routes based on current registered Resolvers:
+Note: Each resolver should have a findAll for Controllers, Routes, Models etc.
+Then for each instance, apply the applier if such exists or use default applier for that type.
+
+Furthermore, it would (perhaps) make sense to have base classes reside in their own namespace. 
+
+Also better to have Mixins and Abstract classes reside in their own namespaces to not pollute and keep distinct!
+
+`Ember.Routes.Mixins.Admin = { ...}` and `Ember.Routes.Abtract.Authenticate = { ...}`
+
+
+The developer should not have to handcode an Applier for every such rule.
+For most cases it could be defined declaratively, and Ember could then generate the Applier repos from this declaration:
+
+```
+routes:
+    groups:
+        admin: [/^Admin/]
+        auth: ['admin', /Post/, ...] // reference groups
+    appliers:   
+        admin: ...
+        'auth': ...
+    }
+```
+
+Much better control and overview from a central declarative location.
+
+This approach could be used for Controllers, Models and Routes (and perhaps Views?)
+
+# Detailed design
+
+
+On application load:
+
+```
+# Find all Routes based on current registered Resolvers:
+# Each resolver should have a findAll for Controllers, Routes, Models etc.
+
+```
+// shared base logic! (base class :) )
+Ember.Applier.Base = Ember.Object({
+    findAll: function() {}, // return all routes (not mixins or abstract!)
+    apply: function() {
+        this.findAll.forEach(function(obj) {    
+            if (res = App.appliers(self.type).get(obj)) {
+                # use declarative Extend rule if any matches for route of this name
+                # could also apply one or more mixins
+                res.applyOn(obj);
+            } else {
+                # fallback strategy (default for type)
+                obj = self.defaultStrategy(obj);
+            }
+        })    
+    },
+    defaultStrategy: function(obj) {
+        obj.extend(this.defaultBaseClass)
+    }
+})
+
+RouteApplier = Ember.Applier.Base.extend({
+    type: 'Routes',
+    defaultBaseClass: Ember.Route,    
+})
+
+And so on...
+```
+
+Registering an applier:
+- baseClass - the BaseClass to apply (use Ember.Route if null)
+- mixinClasses - mixinClasses (optional)
+- applyFor - patterns for which to apply this Applier (default *)
+- applyOn (optional) - custom apply logic (default just extend with baseclass)
+
+```
+App.Appliers.repo('Routes').set('Authentication', {
+    baseClass: Ember.Routes.Abstract.Authentication,
+    mixinClasses: [Ember.Routes.Abstract.Authorize]
+    applyFor: [/^Admin/, /Post/],
+
+    // effectively this would be ._super (i.e base implementation)
+    applyOn: (object) {
+        obj = object.extend(this.baseClass || Ember.Route);
+
+        if (!mixinClasses.isEmpty) {
+            mixinClasses.forEach(function(mixinClass) { obj.mixin mixinClass})
+        }
+        return obj
+    }    
+}    
+```
+
+Of course the developer should not have to handcode this for every such rule.
+For most cases it could be defined declaratively, and Ember could then generate the Applier repos from this declaration:
+
+``
+Ember.Routes.Mixins.Admin = {
+  ...  
+}
+```
+
+```
+routes:
+    groups:
+        admin: [/^Admin/]
+        auth: ['admin', /Post/] // references 'admin' group
+    appliers:   
+        admin: {
+            mixins: [Admin] // Mixins.Admin
+        }
+        'auth': {
+            baseClass: 'Abstract.Authentication', // relative to Ember.Routes
+            mixins: [Abstract.Authorize]
+        }
+    }
+```
+
+# Drawbacks
+
+This is quite a big change and perhaps the whole MetaMagic part should reside in a separate (addin /plugin) to be included as an opt-in.
+The basic Namespace part first described could however be part of core.
+
+The MetaMagic part just goes to demonstrate some of the power this sort of approach would allow ;)
+
+# Alternatives
+
+What other designs have been considered? What is the impact of not doing this?
+
+See drawbacks
+
+# Unresolved questions
+
+What parts of the design are still TBD?
+
+You tell me...


### PR DESCRIPTION
Contains basic proposal that would be an opt-in and not break with any current (or future) app if implemented.
An app could even be made to have multiple resolvers in a chain (`Ember.MultiResolver`), using one as primary and one or more as fallback strategies (useful when migrating from one strategy to another or when mixing code from projects using different naming strategies...) 

On another note, it would be cool to use the same approach as for Resolver, so as to have both a `Ember.Route` and `Ember.DefaultRoute`, with the default setup being that `Ember.Route` simply is an alias (pointer to) `Ember.DefaultRoute` but allowing `Ember.Route` to be overridden while still preserving the default functionality... but I guess this could also be achieved simply having `App.Route` extending from `Ember.DefaultRoute`.

Same approach for Controller, View etc. This opens up a lot of new possibilities :)

Also, if we have convention like `App.Routes.Mixins` and `App.Routes.Abstract` the should live in folders `app/routes/mixins` and `app/routes/mixins`

Using such a convention, we could simplify mixin-in multiple mixins like this

```
// cumbersome...
App.CommentView = App.Route.extend(App.Routes.Mixins.MyMixin, .App.Routes.Mixins.MyOtherMixin, {...})

// alternative
App.CommentView = App.Route.extend({...}).mixin(App.Routes.Mixins: ['MyMixin', 'MyOtherMixin'])

// or by convention, always assume using App.Routes.Mixins as scope for a Route
App.CommentView = App.Route.extend({...}).mixin('MyMixin', 'MyOtherMixin')
```

Too many ideas on this topic :)

Just discovered you can do:

`App.__container__.lookup('application:controllers').get(xxx)``

But I don't see that changing much. Still the current flat naming standard feels awkward and limiting.
