### PR TITLE
Computed properties change gate

### DIFF
--- a/0000-computed-properties-change-gate.md
+++ b/0000-computed-properties-change-gate.md
@@ -42,7 +42,7 @@ obj.get('firstInitial');  // Calls the firstInitial function, without need. Retu
 This feels wrong.
 I been told that this idea is in the pipeline, but I wanted to officialize it with this RFC.
 
-### Cavears
+### Caveats
 
 For avoid propagating changes when a CP is recomputed, we need to compare the old value with the new value.
 


### PR DESCRIPTION
I think this is a weird behaviour everybody faced.

When a dependency of a CP changes, that CP is recomputed, but even if the value after being recomputed is the same that it used to be, any other CP depending on the first one is considered stale.
