### PR TITLE
[meta] Add note about filing issues before full RFC PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ If you submit a pull request to implement a new feature without going
 through the RFC process, it may be closed with a polite request to 
 submit an RFC first.
 
+## Gathering feedback before submitting
+
+It's often helpful to get feedback on your concept before diving into the 
+level of API design detail required for an RFC. You can always open an 
+issue on this repo to open up high-level discussion, with the goal of 
+eventually formulating an RFC pull request with the specific implementation
+design.
+
 ## What the process is
 
 In short, to get a major feature added to Ember, one must first get the 


### PR DESCRIPTION
It might be helpful in some cases, as @mixonic [suggested](https://github.com/emberjs/ember.js/issues/11645#issuecomment-118868091), to hold high-level conceptual discussions and organize feedback in an issue prior to diving into the implementation details that a full RFC requires.