### PR TITLE
RFC process improvements.

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -8,18 +8,37 @@ One paragraph explanation of the feature.
 
 # Motivation
 
-Why are we doing this? What use cases does it support? What is the expected outcome?
+Why are we doing this? What use cases does it support? What is the expected
+outcome?
 
 # Detailed design
 
-This is the bulk of the RFC. Explain the design in enough detail for somebody familiar
-with the framework to understand, and for somebody familiar with the implementation to implement.
-This should get into specifics and corner-cases, and include examples of how the feature is used.
-Any new terminology should be defined here.
+This is the bulk of the RFC. Explain the design in enough detail for somebody
+familiar with the framework to understand, and for somebody familiar with the
+implementation to implement. This should get into specifics and corner-cases,
+and include examples of how the feature is used. Any new terminology should be
+defined here.
+
+# How We Teach This
+
+What names and terminology work best for these concepts and why? How is this
+idea best presented? As a continuation of existing Ember patterns, or as a
+wholly new one?
+
+Would the acceptance of this proposal mean the Ember guides must be
+re-organized or altered? Does it change how Ember is taught to new users
+at any level?
+
+How should this feature be introduced and taught to existing Ember
+users?
 
 # Drawbacks
 
-Why should we *not* do this?
+Why should we *not* do this? Please consider the impact on teaching Ember,
+on the integration of this feature with other existing and planned features,
+on the impact of the API churn on existing apps, etc.
+
+There are tradeoffs to choosing any path, please attempt to identify them here.
 
 # Alternatives
 
@@ -27,4 +46,5 @@ What other designs have been considered? What is the impact of not doing this?
 
 # Unresolved questions
 
-What parts of the design are still TBD?
+Optional, but suggested for first drafts. What parts of the design are still
+TBD?

--- a/README.md
+++ b/README.md
@@ -1,85 +1,81 @@
 # Ember RFCs
 
-> Hat tip to the [Rust RFC process].
-
-Many changes, including bug fixes and documentation improvements can be 
+Many changes, including bug fixes and documentation improvements can be
 implemented and reviewed via the normal GitHub pull request workflow.
 
-Some changes though are "substantial", and we ask that these be put 
+Some changes though are "substantial", and we ask that these be put
 through a bit of a design process and produce a consensus among the Ember
 core team.
 
 The "RFC" (request for comments) process is intended to provide a
 consistent and controlled path for new features to enter the framework.
 
-## Active RFC List
-
-* [0015-the-road-to-ember-2-0.md](text/0015-the-road-to-ember-2-0.md)
-* [0045-internet-explorer.md](text/0045-internet-explorer.md)
+[Active RFC List](https://github.com/emberjs/rfcs/pulls)
 
 ## When you need to follow this process
 
-You need to follow this process if you intend to make "substantial" 
+You need to follow this process if you intend to make "substantial"
 changes to Ember, Ember Data or its documentation. What constitutes a
 "substantial" change is evolving based on community norms, but may
 include the following.
 
-   - Any new feature that creates new API surface area, and would
+   - A new feature that creates new API surface area, and would
      require a [feature flag] if introduced.
-   - Removing features that already shipped as part of the release
+   - The removal of features that already shipped as part of the release
      channel.
-
+   - The introduction of new idiomatic usage or conventions, even if they
+     do not include code changes to Ember itself.
 
 Some changes do not require an RFC:
 
    - Rephrasing, reorganizing or refactoring
    - Addition or removal of warnings
-   - Additions that strictly improve objective, numerical quality 
+   - Additions that strictly improve objective, numerical quality
 criteria (speedup, better browser support)
-   - Additions only likely to be _noticed by_ other implementors-of-Ember, 
+   - Additions only likely to be _noticed by_ other implementors-of-Ember,
 invisible to users-of-Ember.
 
-If you submit a pull request to implement a new feature without going 
-through the RFC process, it may be closed with a polite request to 
+If you submit a pull request to implement a new feature without going
+through the RFC process, it may be closed with a polite request to
 submit an RFC first.
 
 ## Gathering feedback before submitting
 
-It's often helpful to get feedback on your concept before diving into the 
-level of API design detail required for an RFC. You can always open an 
-issue on this repo to open up high-level discussion, with the goal of 
+It's often helpful to get feedback on your concept before diving into the
+level of API design detail required for an RFC. **You may open an
+issue on this repo to start a high-level discussion**, with the goal of
 eventually formulating an RFC pull request with the specific implementation
 design.
 
 ## What the process is
 
-In short, to get a major feature added to Ember, one must first get the 
-RFC merged into the RFC repo as a markdown file. At that point the RFC 
-is 'active' and may be implemented with the goal of eventual inclusion 
+In short, to get a major feature added to Ember, one must first get the
+RFC merged into the RFC repo as a markdown file. At that point the RFC
+is 'active' and may be implemented with the goal of eventual inclusion
 into Ember.
 
 * Fork the RFC repo http://github.com/emberjs/rfcs
-* Copy `0000-template.md` to `text/0000-my-feature.md` (where 
+* Copy `0000-template.md` to `text/0000-my-feature.md` (where
 'my-feature' is descriptive. don't assign an RFC number yet).
-* Fill in the RFC. Put care into the details: RFCs that do not
+* Fill in the RFC. Put care into the details: **RFCs that do not
 present convincing motivation, demonstrate understanding of the
 impact of the design, or are disingenuous about the drawbacks or
-alternatives tend to be poorly-received.
+alternatives tend to be poorly-received**.
 * Submit a pull request. As a pull request the RFC will receive design
 feedback from the larger community, and the author should be prepared
 to revise it in response.
-* Build consensus and integrate feedback. RFCs that have broad support 
-are much more likely to make progress than those that don't receive any 
+* Build consensus and integrate feedback. RFCs that have broad support
+are much more likely to make progress than those that don't receive any
 comments.
-* Eventually, somebody on the [core team] will either accept the RFC by 
-merging the pull request and assigning the RFC a number, at which point 
+* Eventually, somebody on the [core team] will either accept the RFC by
+merging the pull request and assigning the RFC a number, at which point
 the RFC is 'active', or reject it by closing the pull request.
 
 ## The RFC life-cycle
 
-Once an RFC becomes active then authors may implement it and submit the 
-feature as a pull request to the Ember repo. An 'active' is not a rubber 
-stamp, and in particular still does not mean the feature will ultimately 
+Once an RFC becomes active then authors may implement it and submit the
+feature as a pull request to the Ember repo. Becoming 'active' is not a rubber
+stamp, and in particular still does not mean the feature will ultimately
 be merged; it does mean that the core team has agreed to it in principle
 and are amenable to merging it.
 
@@ -87,18 +83,13 @@ Furthermore, the fact that a given RFC has been accepted and is
 'active' implies nothing about what priority is assigned to its
 implementation, nor whether anybody is currently working on it.
 
-Modifications to active RFC's can be done in followup PR's.  We strive
+Modifications to active RFC's can be done in followup PR's. We strive
 to write each RFC in a manner that it will reflect the final design of
 the feature; but the nature of the process means that we cannot expect
 every merged RFC to actually reflect what the end result will be at
 the time of the next major release; therefore we try to keep each RFC
 document somewhat in sync with the language feature as planned,
 tracking such changes via followup pull requests to the document.
-
-An RFC that makes it through the entire process to implementation is
-considered 'complete' and is moved to the 'complete' folder; an RFC
-that fails after becoming active is 'inactive' and moves to the
-'inactive' folder.
 
 ## Implementing an RFC
 
@@ -116,10 +107,13 @@ Each week the [core team] will attempt to review some set of open RFC
 pull requests.
 
 We try to make sure that any RFC that we accept is accepted at the
-Friday team meeting, and reported in the weekly blog post. Every
+Friday team meeting, and reported in [core team notes]. Every
 accepted feature should have a core team champion, who will represent
 the feature and its progress.
+
+**Ember's RFC process owes its inspiration to the [Rust RFC process]**
 
 [Rust RFC process]: https://github.com/rust-lang/rfcs
 [core team]: http://emberjs.com/team/
 [feature flag]: http://emberjs.com/guides/contributing/adding-new-features/
+[core team notes]: https://github.com/emberjs/core-notes/tree/master/ember.js


### PR DESCRIPTION
* Fixes #117
* Related to http://emberjs.com/blog/2016/01/23/core-team-face-to-face-january-2016.html#toc_rfc-improvements
* Add "How We Teach This" section to RFCs
* Make "Unresolved questions" optional but suggested
* Move hat tip to the bottom, not important enough to be at the top
* Replace manually curated "active" list with a link to the open PRs
* Loosen language that implied *any* new API addition no matter how
  minor required an RFC
* Add requirement that significant changes in Ember conventions or
  idiomatic programming style receive an RFC
* Add emphasis to sections of the README
* Drop outdated task of moving an RFC to the "completed" folder
* Link to the core team notes for RFC discussions
* Strengthen request for drawbacks

/cc @mmun @wycats @tomdale @stefanpenner for a few.