### PR TITLE
Deprecate Function.prototype.on, Function.prototype.property, Function.prototype.observes

### DIFF
--- a/text/000-deprecation-native-function-prototype-extensions.md
+++ b/text/000-deprecation-native-function-prototype-extensions.md
@@ -4,12 +4,12 @@
 
 # Deprecate Function.prototype.on, Function.prototype.observes and Function.prototype.property
 
-# Summary
+## Summary
 
 This RFC proposes to deprecate `Function.prototype.on`,
 `Function.prototype.observes` and `Function.prototype.property`
 
-# Motivation
+## Motivation
 
 Ember has been moving away from extending native prototypes due to the confusion
 that this causes users: is it specifically part of Ember, or JavaScript?
@@ -21,7 +21,7 @@ We go from two ways to do something, to one.
 
 [`eslint-plugin-ember` already provides this as a rule](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-function-prototype-extensions.md).
 
-# Transition Path
+## Transition Path
 
 The replacement functionality already exists in the form of `on`, `observer`, and `computed`.
 We don't need to build anything new specifically, however, the bulk of the transition will be
@@ -49,7 +49,7 @@ export default Component.extend({
 We need to create a codemod that will transform code from the `current` form to the
 `proposed` form.
 
-# How We Teach This
+## How We Teach This
 
 On the deprecation guide, we showcase the same example as above. We can explain why
 the proposal was necessary, followed by deprecated to current code examples.
@@ -60,6 +60,6 @@ For example, from the [disabling prototype extensions page](https://guides.ember
 After the deprecated code is removed from Ember, the same page needs to remove the section
 about `Function` prototypes altogether.
 
-# Alternatives
+## Alternatives
 
 None.

--- a/text/000-deprecation-native-function-prototype-extensions.md
+++ b/text/000-deprecation-native-function-prototype-extensions.md
@@ -2,10 +2,12 @@
 - RFC PR: https://github.com/emberjs/rfcs/pull/272
 - Ember Issue:
 
+# Deprecate Function.prototype.on, Function.prototype.observes and Function.prototype.property
+
 # Summary
 
 This RFC proposes to deprecate `Function.prototype.on`,
-`Function.proptotype.observes` and `Function.prototype.property`
+`Function.prototype.observes` and `Function.prototype.property`
 
 # Motivation
 

--- a/text/000-deprecation-native-function-prototype-extensions.md
+++ b/text/000-deprecation-native-function-prototype-extensions.md
@@ -27,6 +27,15 @@ The replacement functionality already exists in the form of `on`, `observer`, an
 We don't need to build anything new specifically, however, the bulk of the transition will be
 focused on deprecating the native prototype extensions.
 
+We need to create a codemod that will transform code from the `deprecated` form to the
+`proposed` form. 
+
+## How We Teach This
+
+On the deprecation guide, we can showcase the same example as above. We can explain why
+the proposal was necessary, followed by a set of examples highlighting the deprecated
+vs current style.
+
 Borrowing from the [ESLint plugin example](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-function-prototype-extensions.md):
 
 ```js
@@ -34,30 +43,25 @@ import { computed, observer } from '@ember/object';
 import { on } from '@ember/object/evented';
 
 export default Component.extend({
-  // current
+  // deprecated
   abc: function() { /* custom logic */ }.property('xyz'),
   def: function() { /* custom logic */ }.observe('xyz'),
   ghi: function() { /* custom logic */ }.on('didInsertElement'),
 
-  // proposed
+  // current
   abc: computed('xyz', function() { /* custom logic */ }),
   def: observer('xyz', function() { /* custom logic */ }),
   ghi: on('didInsertElement', function() { /* custom logic */ }),
 });
 ```
 
-We need to create a codemod that will transform code from the `current` form to the
-`proposed` form.
+[The Guides currently discourage the use of `Function` prototype extensions](https://guides.emberjs.com/v2.17.0/configuring-ember/disabling-prototype-extensions/):
 
-## How We Teach This
+> Function is extended with methods to annotate functions as computed properties,
+> via the property() method, and as observers, via the observes() method. Use of
+> these methods is now discouraged and not covered in recent versions of the Guides.
 
-On the deprecation guide, we showcase the same example as above. We can explain why
-the proposal was necessary, followed by deprecated to current code examples.
-
-The Guides currently discourage the use of `Function` prototype extensions.
-For example, from the [disabling prototype extensions page](https://guides.emberjs.com/v2.17.0/configuring-ember/disabling-prototype-extensions/):
-
-After the deprecated code is removed from Ember, the same page needs to remove the section
+After the deprecated code is removed from Ember, we need to remove the section
 about `Function` prototypes altogether.
 
 ## Alternatives

--- a/text/000-deprecation-native-function-prototype-extensions.md
+++ b/text/000-deprecation-native-function-prototype-extensions.md
@@ -24,11 +24,11 @@ We go from two ways to do something, to one.
 ## Transition Path
 
 The replacement functionality already exists in the form of `on`, `observer`, and `computed`.
+
 We don't need to build anything new specifically, however, the bulk of the transition will be
 focused on deprecating the native prototype extensions.
 
-We need to create a codemod that will transform code from the `deprecated` form to the
-`proposed` form. 
+A codemod for this deprecation has to take into consideration that while `foo: function() { /* custom logic */ }.property('bar')` is a `Function.prototype` extension, `foo: observer(function () { /* some custom logic */ }).on('customEvent')` is not.
 
 ## How We Teach This
 
@@ -46,16 +46,18 @@ export default Component.extend({
   // deprecated
   abc: function() { /* custom logic */ }.property('xyz'),
   def: function() { /* custom logic */ }.observe('xyz'),
-  ghi: function() { /* custom logic */ }.on('didInsertElement'),
+  ghi: function() { /* custom logic */ }.on('didInsertElement'),
+  jkl: function() { /* custom logic */ }.on('customEvent'),
 
   // current
   abc: computed('xyz', function() { /* custom logic */ }),
   def: observer('xyz', function() { /* custom logic */ }),
-  ghi: on('didInsertElement', function() { /* custom logic */ }),
+  didInsertElement() { /* custom logic */ }),
+  jkl: on('customEvent', function() { /* custom logic */ }),
 });
 ```
 
-[The Guides currently discourage the use of `Function` prototype extensions](https://guides.emberjs.com/v2.17.0/configuring-ember/disabling-prototype-extensions/):
+The official Guides currently [discourage the use of `Function.prototype` extensions](https://guides.emberjs.com/v2.17.0/configuring-ember/disabling-prototype-extensions/):
 
 > Function is extended with methods to annotate functions as computed properties,
 > via the property() method, and as observers, via the observes() method. Use of

--- a/text/000-deprecation-native-function-prototype-extensions.md
+++ b/text/000-deprecation-native-function-prototype-extensions.md
@@ -1,5 +1,5 @@
 - Start Date: 2017-11-20
-- RFC PR:
+- RFC PR: https://github.com/emberjs/rfcs/pull/272
 - Ember Issue:
 
 # Summary
@@ -13,16 +13,16 @@ Ember has been moving away from extending native prototypes due to the confusion
 that this causes users: is it specifically part of Ember, or JavaScript?
 
 Continuing in that direction, we should consider recommending the usage of
-`Ember.on` `Ember.observer` and `Ember.computed` as opposed to their native
-prototype extension equivalents. We go from two ways to do something, to one.
-
+[`on` (`@ember/object/evented`)](https://emberjs.com/api/ember/2.18/classes/@ember%2Fobject%2Fevented/methods/on?anchor=on), [`observer` (`@ember/object`)](https://emberjs.com/api/ember/2.18/classes/@ember%2Fobject/methods/observer?anchor=observer) and [`computed` (`@ember/object`)](https://emberjs.com/api/ember/2.18/classes/@ember%2Fobject/methods/computed?anchor=computed) as opposed to their native
+prototype extension equivalents.
+We go from two ways to do something, to one.
 
 [`eslint-plugin-ember` already provides this as a rule](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-function-prototype-extensions.md).
 
 # Transition Path
 
-The replacement functionality already exists in the form of `Ember.{on, observer, computed}`.
-We don't need to build anything new specifically, however the bulk of the transition will be
+The replacement functionality already exists in the form of `on`, `observer`, and `computed`.
+We don't need to build anything new specifically, however, the bulk of the transition will be
 focused on deprecating the native prototype extensions.
 
 Borrowing from the [ESLint plugin example](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-function-prototype-extensions.md):
@@ -50,9 +50,9 @@ We need to create a codemod that will transform code from the `current` form to 
 # How We Teach This
 
 On the deprecation guide, we showcase the same example as above. We can explain why
-the proposal was necessary, followed by a `deprecated / current` snippet.
+the proposal was necessary, followed by deprecated to current code examples.
 
-The Ember guides currently discourages the use of Function prototype extensions.
+The Guides currently discourage the use of `Function` prototype extensions.
 For example, from the [disabling prototype extensions page](https://guides.emberjs.com/v2.17.0/configuring-ember/disabling-prototype-extensions/):
 
 After the deprecated code is removed from Ember, the same page needs to remove the section
@@ -60,4 +60,4 @@ about `Function` prototypes altogether.
 
 # Alternatives
 
-Leave things as is.
+None.

--- a/text/000-deprecation-native-function-prototype-extensions.md
+++ b/text/000-deprecation-native-function-prototype-extensions.md
@@ -1,0 +1,63 @@
+- Start Date: 2017-11-20
+- RFC PR:
+- Ember Issue:
+
+# Summary
+
+This RFC proposes to deprecate `Function.prototype.on`,
+`Function.proptotype.observes` and `Function.prototype.property`
+
+# Motivation
+
+Ember has been moving away from extending native prototypes due to the confusion
+that this causes users: is it specifically part of Ember, or JavaScript?
+
+Continuing in that direction, we should consider recommending the usage of
+`Ember.on` `Ember.observer` and `Ember.computed` as opposed to their native
+prototype extension equivalents. We go from two ways to do something, to one.
+
+
+[`eslint-plugin-ember` already provides this as a rule](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-function-prototype-extensions.md).
+
+# Transition Path
+
+The replacement functionality already exists in the form of `Ember.{on, observer, computed}`.
+We don't need to build anything new specifically, however the bulk of the transition will be
+focused on deprecating the native prototype extensions.
+
+Borrowing from the [ESLint plugin example](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-function-prototype-extensions.md):
+
+```js
+import { computed, observer } from '@ember/object';
+import { on } from '@ember/object/evented';
+
+export default Component.extend({
+  // current
+  abc: function() { /* custom logic */ }.property('xyz'),
+  def: function() { /* custom logic */ }.observe('xyz'),
+  ghi: function() { /* custom logic */ }.on('didInsertElement'),
+
+  // proposed
+  abc: computed('xyz', function() { /* custom logic */ }),
+  def: observer('xyz', function() { /* custom logic */ }),
+  ghi: on('didInsertElement', function() { /* custom logic */ }),
+});
+```
+
+We need to create a codemod that will transform code from the `current` form to the
+`proposed` form.
+
+# How We Teach This
+
+On the deprecation guide, we showcase the same example as above. We can explain why
+the proposal was necessary, followed by a `deprecated / current` snippet.
+
+The Ember guides currently discourages the use of Function prototype extensions.
+For example, from the [disabling prototype extensions page](https://guides.emberjs.com/v2.17.0/configuring-ember/disabling-prototype-extensions/):
+
+After the deprecated code is removed from Ember, the same page needs to remove the section
+about `Function` prototypes altogether.
+
+# Alternatives
+
+Leave things as is.


### PR DESCRIPTION
Attempts to introduce https://github.com/emberjs/rfcs/issues/271 to existing RFCs.