### PR TITLE
Fix is-active helper example in router-service

### DIFF
--- a/text/0095-router-service.md
+++ b/text/0095-router-service.md
@@ -106,7 +106,7 @@ export default Helper.extend({
     } else {
       allModels = models;
     }
-    return this.get('router').isActive(routeName, ...models, hash.queryParams);
+    return this.get('router').isActive(routeName, ...allModels, hash.queryParams);
   },
   didTransition: observer('router.currentRoute', function() {
     this.recompute();


### PR DESCRIPTION
`allModels` is currently unused. It should be returned as the new models