### PR TITLE
Deprecating Ember.Logger

### DIFF
--- a/text/0000-deprecate-ember-logger.md
+++ b/text/0000-deprecate-ember-logger.md
@@ -6,17 +6,17 @@
 
 ## Summary
 
-This RFC provides for the deprecation and eventual removal of Ember.Logger.
+This RFC recommends the deprecation and eventual removal of `Ember.Logger`.
 
 ## Motivation
 
 There are a variety of features of Ember designed to support old browsers,
-features that are no longer needed. Ember.Logger came into being because
+features that are no longer needed. `Ember.Logger` came into being because
 the browser support for the console was inconsistent. In some browsers,
 like Internet Explorer 9, the console only existed when the developer tools
-panel was open, which caused references to the console object's methods to
-fail to execute. Ember.Logger provided methods that would route to the 
-console when it was available.
+panel was open, which caused null references and program crashes when run
+with the console closed. `Ember.Logger` provided methods that would route to 
+the console when it was available.
 
 With Ember 3.x, Ember no longer supports these older browsers, and hence this
 feature no longer serves a purpose. Removing it will make Ember smaller and 
@@ -24,242 +24,133 @@ lighter.
 
 ## Detailed design
 
+For the most part, this is a 1:1 substitution of the global console object 
+for `Ember.Logger`. However, Node only added support for `console.debug` in 
+Node version 9. To support earlier versions of Node, our codemod will need to 
+use `console.log`, rather than `console.debug`, as the replacement for 
+`Logger.debug`, except for add-ons that specify that they only support Node 
+version 9 and beyond.
+
 ### For framework developers
 
-Remove the following 8 direct uses of Ember.Logging from ember.js and 
-ember-data: 
+Remove the following direct uses of `Ember.Logger` from the ember.js and 
+ember-data projects: 
 
-ember-debug:
-*  deprecate (deprecate.js) - Logger.warn
-*  debug (index.js) - Logger.info
-*  warn (warn.js) - Logger.warn
-ember-routing (router.js):
-*  transitioned to - Logger.log
-*  preparing to transition to - Logger.log
-*  intermediate-transitioned to - Logger.log
-ember-testing:
-*  Testing paused (pause_test.js) - Logger.info
-*  Catch-all handler (adapter.js) - Logger.error
-ember-data:
-*  tests\test-helper.js:      Ember.Logger.log(reason, reason.stack);
-(Note: I found one usage in ember-data, but emberobserver claims two more.)
+* `ember-debug`:
+    *  deprecate (`ember-debug\lib\deprecate.js`) - `Logger.warn`
+    *  debug (`ember-debug\lib\index.js`) - `Logger.info`
+    *  warn (`ember-debug\lib\warn.js`) - `Logger.warn`
+* `ember-routing` (`ember-routing\lib\system\router.js`):
+    *  transitioned to - `Logger.log`
+    *  preparing to transition to - `Logger.log`
+    *  intermediate-transitioned to - `Logger.log`
+* `ember-testing`:
+    *  Testing paused (`ember-testing\lib\helpers\pause_test.js`) - `Logger.info`
+    *  Catch-all handler (`ember-testing\lib\test\adapter.js`) - `Logger.error`
+* `ember-data`:
+    *  `tests\test-helper.js`- `Logger.log`
 
 Adjust all test code that redirects logging and sets it back:
 
-ember:
-*    routing: basic_test.js (adjust)
-ember-application - system: 
-*    logging_test.js (remove?)
-*    dependency_injection : default_resolver.test.js (adjust)
-ember-glimmer - integration: 
-*    helpers: log-test.js (remove)
+* `ember\tests\routing\basic_test.js` (adjust)
+* `ember-application\tests\system\dependency_injection\default_resolver_test.js` (adjust)
+* `ember-application\tests\system\logging_test.js` (remove?)
+* `ember-glimmer\tests\integration\helpers\log-test.js` (remove?)
 
-None of the uses of Ember.Logging in ember.js or ember-data are using 
-Ember.debug, which will simplify matters.
+Note: None of the uses of `Ember.Logger` in `ember.js` or `ember-data` involve
+`Ember.debug`, so that issue doesn't affect the Ember.js code directly.
 
-### For Framework Users
+Add deprecation warnings to the implementation: `ember-console\lib\index.js`.
+Bear in mind that the deprecation mechanism currently calls `Logger.warn`, so 
+that code should be changed _first_ or this change will be very difficult 
+to debug.
 
-For the most part, this is a 1:1 substitution of the global console object 
-for Ember.Logging. The only anomaly remaining in Javascript engine console 
-support is that versions of Node earlier than Node 9 do not support 
-console.debug, so console.log will need to be used as the replacement for 
-Logging.debug, rather than console.debug, unless the minimum Node support 
-level is set to Node 9.
+### Codemod
 
-The following high-impact packages (9 or 10 or a * on EmberObserver) are 
-calling Ember.Logging and should probably be given an early heads-up to 
-adjust their code to use console in advance of the release containing the 
-deprecation to limit the level of pain that their users experience. In 
-the order of their reliance on Ember.Logging:
+Provide a codemod that developers can use to switch references to the methods 
+of `Ember.Logger` to use `console` instead. I will definitely need help here.
 
-* ember-concurrency (15)
-* ember-cli-deprecation-workflow (9)
-* ember-stripe-service (9)
-* semantic-ui-ember (7)
-* ember-resolver (6)
-* ember-cli-page-object (4) 
-* ember-cli-sentry (3)
-* ember-islands (3)
-* ember-states (3)
-* ember-cli-pagination (2)
-* ember-cli-clipboard (1)
-* ember-cli-fastboot (1)
-* ember-elsewhere (1)
-* ember-i18n (1)
-* ember-simple-auth-token (1)
-* ember-svg-jar (1)
-* liquid-fire (1)
+### For Add-On Developers
 
-### Timeline
+The following high-impact packages (9 or 10 or a * on EmberObserver) use 
+`Ember.Logger` and should probably be given an early heads-up to adjust 
+their code to use `console` before this change is released. This will limit 
+the level of pain that their users experience when the deprecation is released.
 
-1. Remove all uses of Ember.Logging from other Ember and ember-data code.
-This is particularly important for any methods involved in reporting 
-deprecation. [Date? This could start now.]
-2. Write and test codemod to change code to use console and make it available. [Any time]
-3. Inform users that Ember.Logging will be deprecated and in what release. [When we know schedule]
-4. Call deprecation APIs from all Logging methods in @ember-console/index.js [Once codemod is out there]
-5. In documentation, offer suggestions for babel plugins available to suppress [Before we release]
-console calls in production builds with any special instructions for how to 
-use them in ember-cli broccoli builds.
-6. In due season, the deprecation will appear in a release. [When?]
+In the order of their number of references to `Ember.Logger`:
+
+* `ember-concurrency` (15)
+* `ember-cli-deprecation-workflow` (9)
+* `ember-stripe-service` (9)
+* `semantic-ui-ember` (7)
+* `ember-resolver` (6)
+* `ember-cli-page-object` (4) 
+* `ember-cli-sentry` (3)
+* `ember-islands` (3)
+* `ember-states` (3)
+* `ember-cli-pagination` (2)
+* `ember-cli-clipboard` (1)
+* `ember-cli-fastboot` (1)
+* `ember-elsewhere` (1)
+* `ember-i18n` (1)
+* `ember-simple-auth-token` (1)
+* `ember-svg-jar` (1)
+* `liquid-fire` (1)
+
+For details, see https://emberobserver.com/code-search?codeQuery=Ember.Logger.
 
 ## How we teach this
 
+### Communication of change
+
+We need to inform users that `Ember.Logger` will be deprecated and in what 
+release it will occur. 
+
 ### Official code bases and documentation
 
-We do not currently actively teach the use of Ember.Logger. We will need to 
-remove any passing references to Ember.Logger from the Ember guides 
-and from the Super Rentals tutorial, if any such references exist. 
+We do not currently actively teach the use of `Ember.Logger`. We will need to 
+remove any passing references to `Ember.Logger` from the Ember guides 
+from the Super Rentals tutorial, and anywhere else it appears on the website.
 
-Once it is gone from the code, we need to verify it no longer appears in the 
-API listings.
+Once it is gone from the code, we also need to verify it no longer appears in 
+the API listings. 
 
-Likewise, we will need to remove the use of Ember.Logger from ember, ember-data, 
-and the website.
+We should offer suggestions for babel plugins available to suppress console 
+calls in production builds with any special instructions for how to use them in 
+`ember-cli` broccoli builds.
 
 ## Drawbacks
 
-191 projects in Ember Inspector are using it. It has been there and documented 
-for a long time. So this deprecation will cause API churn on a lot of projects.
-Hopefully providing a codemod to replace Ember.Logger calls with the 
-corresponding console calls will make this transition relatively painless.
+191 projects in Ember Inspector are using `Ember.Logger`. It has been there and 
+documented for a long time. So this deprecation will cause some level of change 
+on many projects. 
 
-However, those using Logging.debug as something different from Logging.log
-may beg to differ, even though under the covers Logging.debug only calls 
-console.debug if it exists, calling console.log otherwise.
+This, of course, can be said for almost any deprecation, and Ember's 
+disciplined approach to deprecation has been repeatedly shown to ease things. 
+Providing a codemod to replace `Ember.Logger` calls with the corresponding 
+console calls should make this transition relatively painless. Also, only 
+twenty of those packages have more than six references to `Ember.Logger`, 
+so the level of effort to make the change, even by hand, will be very small.
+
+Those using `Logger.debug` as something different from `Logger.log`may have at 
+least a theoretical concern. Under the covers `Logger.debug` only calls 
+`console.debug` if it exists, calling `console.log` otherwise. The only 
+platform where the difference between the two is visible in the console is on 
+Safari. We can encourage folks with a tangible, practical concern about this to
+speak up during the comment period, but I don't anticipate this will have much 
+impact.
 
 ## Alternatives
 
-1. Leave things as they are, perhaps providing @ember/console module interface.
+1. Leave things as they are, perhaps providing an `@ember/console` module interface.
 
-2. Extract Ember.Logging into its own (tiny) @ember/logging package as a shim for users.
+2. Extract `Ember.Logger` into its own (tiny) `@ember/console` package as a shim for users.
 
 ## Unresolved questions
 
 What mechanisms are available with Babel to suppress console calls in production builds? 
 Which if any would we point users toward?
 
-How do I write a codemod? I may need help on this part.
-
-How do we deal with Logging.debug in the codemod? Do we provide separate options for those
-who might use Node < 9 and those who are confident they will only use Node 9 or later? 
-
-## Raw Data - Remove
-
-ember\lib\index.js:import Logger from 'ember-console';
-ember\lib\index.js:Ember.Logger = Logger;
-ember\tests\routing\basic_test.js:import Logger from 'ember-console';
-ember\tests\routing\basic_test.js:let Router, App, router, registry, container, originalLoggerError, originalRenderSupport;
-ember\tests\routing\basic_test.js:      originalLoggerError = Logger.error;
-ember\tests\routing\basic_test.js:      Logger.error = originalLoggerError;
-ember\tests\routing\basic_test.js:  Logger.error = function(initialMessage, errorMessage, errorStack) {
-ember\tests\routing\basic_test.js:  Logger.error = function(initialMessage, errorMessage, errorStack) {
-ember\tests\routing\basic_test.js:  Logger.error = function(initialMessage) {
-ember\tests\routing\basic_test.js:  let originalLoggerError = Logger.error;
-ember\tests\routing\basic_test.js:  Logger.error = function(initialMessage, errorMessage) {
-ember\tests\routing\basic_test.js:  Logger.error = originalLoggerError;
-ember\tests\routing\basic_test.js:  Logger.error = function() {
-ember-application\tests\system\dependency_injection\default_resolver_test.js:    assert.equal(infoCount, 0, 'Logger.info should not be called if LOG_RESOLVER is not set');
-ember-application\tests\system\logging_test.js:import Logger from 'ember-console';
-ember-application\tests\system\logging_test.js:    this._originalLogger = Logger.info;
-ember-application\tests\system\logging_test.js:    Logger.info = (_, {fullName}) => {
-ember-application\tests\system\logging_test.js:    Logger.info = this._originalLogger;
-ember-console\lib\index.js:  @class Logger
-ember-console\lib\index.js:    Ember.Logger.log('log value of foo:', foo);
-ember-console\lib\index.js:   @for Ember.Logger
-ember-console\lib\index.js:    Ember.Logger.warn('Something happened!');
-ember-console\lib\index.js:   @for Ember.Logger
-ember-console\lib\index.js:    Ember.Logger.error('Danger! Danger!');
-ember-console\lib\index.js:   @for Ember.Logger
-ember-console\lib\index.js:    Ember.Logger.info('log value of foo:', foo);
-ember-console\lib\index.js:   @for Ember.Logger
-ember-console\lib\index.js:    Ember.Logger.debug('log value of foo:', foo);
-ember-console\lib\index.js:   @for Ember.Logger
-ember-console\lib\index.js:   If the value passed into `Ember.Logger.assert` is not truthy it will throw an error with a stack trace.
-ember-console\lib\index.js:    Ember.Logger.assert(true); // undefined
-ember-console\lib\index.js:    Ember.Logger.assert(true === false); // Throws an Assertion failed error.
-ember-console\lib\index.js:    Ember.Logger.assert(true === false, 'Something invalid'); // Throws an Assertion failed error with message.
-ember-console\lib\index.js:   @for Ember.Logger
-ember-debug\lib\deprecate.js:import Logger from 'ember-console';
-ember-debug\lib\deprecate.js:    Logger.warn(`DEPRECATION: ${updatedMessage}`);
-ember-debug\lib\deprecate.js:      Logger.warn(`DEPRECATION: ${updatedMessage}${stackStr}`);
-ember-debug\lib\index.js:import Logger from 'ember-console';
-ember-debug\lib\index.js:    Logger.debug(`DEBUG: ${message}`);
-ember-debug\lib\index.js:    Logger.info.apply(undefined, arguments);
-ember-debug\lib\warn.js:import Logger from 'ember-console';
-ember-debug\lib\warn.js:    Logger.warn(`WARNING: ${message}`);
-ember-debug\lib\warn.js:    if ('trace' in Logger) {
-ember-debug\lib\warn.js:      Logger.trace();
-ember-glimmer\tests\integration\helpers\log-test.js:import Logger from 'ember-console';
-ember-glimmer\tests\integration\helpers\log-test.js:    this.originalLog = Logger.log;
-ember-glimmer\tests\integration\helpers\log-test.js:    Logger.log = (...args) => {
-ember-glimmer\tests\integration\helpers\log-test.js:    Logger.log = this.originalLog;
-ember-routing\lib\system\router.js:import Logger from 'ember-console';
-ember-routing\lib\system\router.js:        routerMicrolib.log = Logger.debug;
-ember-routing\lib\system\router.js:        Logger.log(`Transitioned into '${EmberRouter._routePath(infos)}'`);
-ember-routing\lib\system\router.js:        Logger.log(`Preparing to transition from '${EmberRouter._routePath(oldInfos)}' to '${EmberRouter._routePath(newInfos)}'`);
-ember-routing\lib\system\router.js:        Logger.log(`Intermediate-transitioned into '${EmberRouter._routePath(infos)}'`);
-ember-routing\lib\system\router.js:  Logger.error.apply(this, errorArgs);
-ember-testing\lib\helpers\pause_test.js:import Logger from 'ember-console';
-ember-testing\lib\helpers\pause_test.js:  Logger.info('Testing paused. Use `resumeTest()` to continue.');
-ember-testing\lib\test\adapter.js:import Logger from 'ember-console';
-ember-testing\lib\test\adapter.js:  Logger.error(error.stack);
-
-ember-data:
-    tests\test-helper.js:      Ember.Logger.log(reason, reason.stack);
-    
-    already using console.log in several places, mostly in addons:
-    addon\-private\system\model\model.js:      console.log(field, kind);
-    addon\-private\system\model\model.js:      console.log(name, meta);
-    addon\-private\system\model\model.js:      console.log(field, type);
-    addon\-private\system\model\model.js:      console.log(name, meta);
-    addon\-private\system\model\model.js:      console.log(name, type);
-    addon\-private\system\model\states.js:      console.log("Received myEvent with", param);
-    addon\-private\system\record-arrays\adapter-populated-record-array.js:    console.log(admins.get("length")); // 42
-    addon\-private\system\record-arrays\adapter-populated-record-array.js:    console.log(admins.get("length")); // 123
-    addon\-private\system\store.js:      console.log(`Currently logged in as ${username}`);
-    addon\-private\system\store.js:      console.log(user); // null
-    benchmarks\config.js:    // { key: "stats.store.modelFor", name: 'modelFor', transform: function(t, c) { console.log(t); return t; }, rollup: false },
-    node-tests\nodetest-runner.js:  console.log('Verifing `.only` in tests');
-    node-tests\nodetest-runner.js:    console.log('No `.only` found');
-    tests\test-helper.js:      Ember.Logger.log(reason, reason.stack);
-
-Really useful URL: https://emberobserver.com/code-search?codeQuery=Ember.Logger
-Results:
-    191 Add-Ons use Ember.Logger.
-    Notables:
-        ember-source (19 usages)
-        ember-concurrency (15 usages)
-        ember-stripe-service (9 usages)
-        ember-cli-page-object (4 usages) 
-        ember-data (3 usages)
-        ember-cli-fastboot (1 usage)
-        ember-i18n (1 usage)
-        ember-simple-auth-token (1 usage)
-        ember-svg-jar (1 usage)
-        liquid-fire (1 usage)
-
-Preparation for writing this section:
-
-0. Read the source of Ember.Logger and enumerate the methods, understanding any corner cases they may raise for replacement with console commands. [Done]
-
-ember-console exports assert, debug, error, info, log, warn.
-Chrome, Firefox, Edge, IE11, Safari support all of these.
-Node 6 supports all of them except debug, which doesn't appear until Node 9.x.
-
-So the only thing even remotely edgy surrounds what to do with Logger.debug(). The current implementation checks if console supports debug and either issues console.debug() or console.log() accordingly.
-
-1. Mentally implement the deprecation itself on each method and enumerate the likely fallout, if any. [Done]
-
-The mechanism that reports deprecations uses these calls, so we would need that code to call the console directly before we attempted to flag these calls for deprecation. In fact, we would probably want to replace all eight of the internal usages.
-
-A number of tests redefine Ember.Logger temporarily as a means of interception. If all of those uses are going to console, it should still be possible to redirect those, but it may make debugging uncomfortable.
-
-2. Mentally implement the codemod to replace Ember.Logging calls with console calls. Understand what will be easy or difficult.
-
-I have real doubts about my ability to do this - especially if it involves familiarity with ASTs - but it could be an opportunity to learn.
-
-3. Enumerate the places in the emberjs source that call Ember.Logger and its methods. Get a feeling for how many do and what methods they use a lot of. [Done]
-
-4. Research any Babel plugins which remove console calls.
-
+How do we deal with `Logger.debug` in the codemod? Do we provide separate options for those
+who might use Node versions earlier than 9 and those who are confident they will only use 
+Node version 9 or later? 

--- a/text/0000-deprecate-ember-logger.md
+++ b/text/0000-deprecate-ember-logger.md
@@ -33,13 +33,11 @@ version 9 and beyond.
 
 When a project is built for production, `Ember.Logger` calls become a no-op. 
 Replacing `Ember.Logger` calls with console calls will require some other 
-mechanism to suppress logging in production builds. Fortunately, there are 
-Babel plugins to suppress console interaction. Using a Babel plugin is 
-a far more comprehensive solution than relying upon `Ember.logger`, as it 
-will catch those places where the developer directly used a `console.log` 
-call, or - worse - a `debugger` statement. As a part of implementing this 
-RFC, we will need to ensure it is easy for a developer to incorporate that 
-support into the `ember-cli` Broccoli pipeline.
+mechanism to suppress logging in production builds. Fortunately, the 
+`babel-plugin-transform-remove-console` will suppress console 
+interaction, a far more comprehensive solution than relying upon
+`Ember.logger`. We will need to supply instructions for setting this up (for
+production builds only) in the `ember-cli` Broccoli pipeline.
 
 
 ### Within the framework
@@ -127,9 +125,18 @@ from the Super Rentals tutorial, and anywhere else it appears on the website.
 Once it is gone from the code, we also need to verify it no longer appears in 
 the API listings. 
 
-We should offer suggestions for babel plugins available to suppress console 
-calls in production builds with any special instructions for how to use them in 
-`ember-cli` broccoli builds.
+We must supply instructions for using `babel-plugin-transform-remove-console`
+in `ember-cli` so it is only applied in production builds.
+
+We must provide an entry in the deprecation guide for this change:
+* offering instruction for using the codemod to perform the change automatically
+with before and after code samples.
+* documenting the use of `babel-plugin-transform-remove-console` in the 
+`ember-cli` build to suppress console calls in production.
+the console calls in production code. 
+* describing the issue with using console.debug on node versions 
+earlier than Node 9 and what provision the codemod has made to deal with it.
+* describing alternative ways of dealing with eslint's `no-console` messages.
 
 ## Drawbacks
 
@@ -155,15 +162,23 @@ impact.
 
 ## Alternatives
 
-1. Leave things as they are, perhaps providing an `@ember/console` module interface.
+1. Leave things as they are, perhaps providing an `@ember/console` module 
+interface.
 
-2. Extract `Ember.Logger` into its own (tiny) `@ember/console` package as a shim for users.
+2. Extract `Ember.Logger` into its own (tiny) `@ember/console` package as 
+a shim for users.
 
 ## Unresolved questions
 
-What mechanisms are available with Babel to suppress console calls in production builds? 
-Which if any would we point users toward?
+How do we deal with `Logger.debug` in the codemod? Do we provide separate 
+options for those who might use Node versions earlier than 9 and those who 
+are confident they will only use Node version 9 or later? Do we have the 
+codemod inject a polyfill for console.debug that calls console.log? Do we
+provide one separately for the user to apply? Or does that become a fastboot 
+concern, since that's the primary driver for running ember projects in node.
 
-How do we deal with `Logger.debug` in the codemod? Do we provide separate options for those
-who might use Node versions earlier than 9 and those who are confident they will only use 
-Node version 9 or later? 
+What do we do about the eslint `no-console` flag? Some developers are 
+using `Ember.Logger` right now to work around it. Others are providing 
+their own logging service. If we encourage the use of a Babel plugin 
+to strip console calls, should we remove `no-console` from the default 
+flags that `ember-cli` ships?

--- a/text/0000-deprecate-ember-logger.md
+++ b/text/0000-deprecate-ember-logger.md
@@ -1,0 +1,265 @@
+- 2018-01-17
+- RFC PR: (leave this empty)
+- Ember Issue: (leave this empty)
+
+# Deprecation of Ember.Logger
+
+## Summary
+
+This RFC provides for the deprecation and eventual removal of Ember.Logger.
+
+## Motivation
+
+There are a variety of features of Ember designed to support old browsers,
+features that are no longer needed. Ember.Logger came into being because
+the browser support for the console was inconsistent. In some browsers,
+like Internet Explorer 9, the console only existed when the developer tools
+panel was open, which caused references to the console object's methods to
+fail to execute. Ember.Logger provided methods that would route to the 
+console when it was available.
+
+With Ember 3.x, Ember no longer supports these older browsers, and hence this
+feature no longer serves a purpose. Removing it will make Ember smaller and 
+lighter.
+
+## Detailed design
+
+### For framework developers
+
+Remove the following 8 direct uses of Ember.Logging from ember.js and 
+ember-data: 
+
+ember-debug:
+*  deprecate (deprecate.js) - Logger.warn
+*  debug (index.js) - Logger.info
+*  warn (warn.js) - Logger.warn
+ember-routing (router.js):
+*  transitioned to - Logger.log
+*  preparing to transition to - Logger.log
+*  intermediate-transitioned to - Logger.log
+ember-testing:
+*  Testing paused (pause_test.js) - Logger.info
+*  Catch-all handler (adapter.js) - Logger.error
+ember-data:
+*  tests\test-helper.js:      Ember.Logger.log(reason, reason.stack);
+(Note: I found one usage in ember-data, but emberobserver claims two more.)
+
+Adjust all test code that redirects logging and sets it back:
+
+ember:
+*    routing: basic_test.js (adjust)
+ember-application - system: 
+*    logging_test.js (remove?)
+*    dependency_injection : default_resolver.test.js (adjust)
+ember-glimmer - integration: 
+*    helpers: log-test.js (remove)
+
+None of the uses of Ember.Logging in ember.js or ember-data are using 
+Ember.debug, which will simplify matters.
+
+### For Framework Users
+
+For the most part, this is a 1:1 substitution of the global console object 
+for Ember.Logging. The only anomaly remaining in Javascript engine console 
+support is that versions of Node earlier than Node 9 do not support 
+console.debug, so console.log will need to be used as the replacement for 
+Logging.debug, rather than console.debug, unless the minimum Node support 
+level is set to Node 9.
+
+The following high-impact packages (9 or 10 or a * on EmberObserver) are 
+calling Ember.Logging and should probably be given an early heads-up to 
+adjust their code to use console in advance of the release containing the 
+deprecation to limit the level of pain that their users experience. In 
+the order of their reliance on Ember.Logging:
+
+* ember-concurrency (15)
+* ember-cli-deprecation-workflow (9)
+* ember-stripe-service (9)
+* semantic-ui-ember (7)
+* ember-resolver (6)
+* ember-cli-page-object (4) 
+* ember-cli-sentry (3)
+* ember-islands (3)
+* ember-states (3)
+* ember-cli-pagination (2)
+* ember-cli-clipboard (1)
+* ember-cli-fastboot (1)
+* ember-elsewhere (1)
+* ember-i18n (1)
+* ember-simple-auth-token (1)
+* ember-svg-jar (1)
+* liquid-fire (1)
+
+### Timeline
+
+1. Remove all uses of Ember.Logging from other Ember and ember-data code.
+This is particularly important for any methods involved in reporting 
+deprecation. [Date? This could start now.]
+2. Write and test codemod to change code to use console and make it available. [Any time]
+3. Inform users that Ember.Logging will be deprecated and in what release. [When we know schedule]
+4. Call deprecation APIs from all Logging methods in @ember-console/index.js [Once codemod is out there]
+5. In documentation, offer suggestions for babel plugins available to suppress [Before we release]
+console calls in production builds with any special instructions for how to 
+use them in ember-cli broccoli builds.
+6. In due season, the deprecation will appear in a release. [When?]
+
+## How we teach this
+
+### Official code bases and documentation
+
+We do not currently actively teach the use of Ember.Logger. We will need to 
+remove any passing references to Ember.Logger from the Ember guides 
+and from the Super Rentals tutorial, if any such references exist. 
+
+Once it is gone from the code, we need to verify it no longer appears in the 
+API listings.
+
+Likewise, we will need to remove the use of Ember.Logger from ember, ember-data, 
+and the website.
+
+## Drawbacks
+
+191 projects in Ember Inspector are using it. It has been there and documented 
+for a long time. So this deprecation will cause API churn on a lot of projects.
+Hopefully providing a codemod to replace Ember.Logger calls with the 
+corresponding console calls will make this transition relatively painless.
+
+However, those using Logging.debug as something different from Logging.log
+may beg to differ, even though under the covers Logging.debug only calls 
+console.debug if it exists, calling console.log otherwise.
+
+## Alternatives
+
+1. Leave things as they are, perhaps providing @ember/console module interface.
+
+2. Extract Ember.Logging into its own (tiny) @ember/logging package as a shim for users.
+
+## Unresolved questions
+
+What mechanisms are available with Babel to suppress console calls in production builds? 
+Which if any would we point users toward?
+
+How do I write a codemod? I may need help on this part.
+
+How do we deal with Logging.debug in the codemod? Do we provide separate options for those
+who might use Node < 9 and those who are confident they will only use Node 9 or later? 
+
+## Raw Data - Remove
+
+ember\lib\index.js:import Logger from 'ember-console';
+ember\lib\index.js:Ember.Logger = Logger;
+ember\tests\routing\basic_test.js:import Logger from 'ember-console';
+ember\tests\routing\basic_test.js:let Router, App, router, registry, container, originalLoggerError, originalRenderSupport;
+ember\tests\routing\basic_test.js:      originalLoggerError = Logger.error;
+ember\tests\routing\basic_test.js:      Logger.error = originalLoggerError;
+ember\tests\routing\basic_test.js:  Logger.error = function(initialMessage, errorMessage, errorStack) {
+ember\tests\routing\basic_test.js:  Logger.error = function(initialMessage, errorMessage, errorStack) {
+ember\tests\routing\basic_test.js:  Logger.error = function(initialMessage) {
+ember\tests\routing\basic_test.js:  let originalLoggerError = Logger.error;
+ember\tests\routing\basic_test.js:  Logger.error = function(initialMessage, errorMessage) {
+ember\tests\routing\basic_test.js:  Logger.error = originalLoggerError;
+ember\tests\routing\basic_test.js:  Logger.error = function() {
+ember-application\tests\system\dependency_injection\default_resolver_test.js:    assert.equal(infoCount, 0, 'Logger.info should not be called if LOG_RESOLVER is not set');
+ember-application\tests\system\logging_test.js:import Logger from 'ember-console';
+ember-application\tests\system\logging_test.js:    this._originalLogger = Logger.info;
+ember-application\tests\system\logging_test.js:    Logger.info = (_, {fullName}) => {
+ember-application\tests\system\logging_test.js:    Logger.info = this._originalLogger;
+ember-console\lib\index.js:  @class Logger
+ember-console\lib\index.js:    Ember.Logger.log('log value of foo:', foo);
+ember-console\lib\index.js:   @for Ember.Logger
+ember-console\lib\index.js:    Ember.Logger.warn('Something happened!');
+ember-console\lib\index.js:   @for Ember.Logger
+ember-console\lib\index.js:    Ember.Logger.error('Danger! Danger!');
+ember-console\lib\index.js:   @for Ember.Logger
+ember-console\lib\index.js:    Ember.Logger.info('log value of foo:', foo);
+ember-console\lib\index.js:   @for Ember.Logger
+ember-console\lib\index.js:    Ember.Logger.debug('log value of foo:', foo);
+ember-console\lib\index.js:   @for Ember.Logger
+ember-console\lib\index.js:   If the value passed into `Ember.Logger.assert` is not truthy it will throw an error with a stack trace.
+ember-console\lib\index.js:    Ember.Logger.assert(true); // undefined
+ember-console\lib\index.js:    Ember.Logger.assert(true === false); // Throws an Assertion failed error.
+ember-console\lib\index.js:    Ember.Logger.assert(true === false, 'Something invalid'); // Throws an Assertion failed error with message.
+ember-console\lib\index.js:   @for Ember.Logger
+ember-debug\lib\deprecate.js:import Logger from 'ember-console';
+ember-debug\lib\deprecate.js:    Logger.warn(`DEPRECATION: ${updatedMessage}`);
+ember-debug\lib\deprecate.js:      Logger.warn(`DEPRECATION: ${updatedMessage}${stackStr}`);
+ember-debug\lib\index.js:import Logger from 'ember-console';
+ember-debug\lib\index.js:    Logger.debug(`DEBUG: ${message}`);
+ember-debug\lib\index.js:    Logger.info.apply(undefined, arguments);
+ember-debug\lib\warn.js:import Logger from 'ember-console';
+ember-debug\lib\warn.js:    Logger.warn(`WARNING: ${message}`);
+ember-debug\lib\warn.js:    if ('trace' in Logger) {
+ember-debug\lib\warn.js:      Logger.trace();
+ember-glimmer\tests\integration\helpers\log-test.js:import Logger from 'ember-console';
+ember-glimmer\tests\integration\helpers\log-test.js:    this.originalLog = Logger.log;
+ember-glimmer\tests\integration\helpers\log-test.js:    Logger.log = (...args) => {
+ember-glimmer\tests\integration\helpers\log-test.js:    Logger.log = this.originalLog;
+ember-routing\lib\system\router.js:import Logger from 'ember-console';
+ember-routing\lib\system\router.js:        routerMicrolib.log = Logger.debug;
+ember-routing\lib\system\router.js:        Logger.log(`Transitioned into '${EmberRouter._routePath(infos)}'`);
+ember-routing\lib\system\router.js:        Logger.log(`Preparing to transition from '${EmberRouter._routePath(oldInfos)}' to '${EmberRouter._routePath(newInfos)}'`);
+ember-routing\lib\system\router.js:        Logger.log(`Intermediate-transitioned into '${EmberRouter._routePath(infos)}'`);
+ember-routing\lib\system\router.js:  Logger.error.apply(this, errorArgs);
+ember-testing\lib\helpers\pause_test.js:import Logger from 'ember-console';
+ember-testing\lib\helpers\pause_test.js:  Logger.info('Testing paused. Use `resumeTest()` to continue.');
+ember-testing\lib\test\adapter.js:import Logger from 'ember-console';
+ember-testing\lib\test\adapter.js:  Logger.error(error.stack);
+
+ember-data:
+    tests\test-helper.js:      Ember.Logger.log(reason, reason.stack);
+    
+    already using console.log in several places, mostly in addons:
+    addon\-private\system\model\model.js:      console.log(field, kind);
+    addon\-private\system\model\model.js:      console.log(name, meta);
+    addon\-private\system\model\model.js:      console.log(field, type);
+    addon\-private\system\model\model.js:      console.log(name, meta);
+    addon\-private\system\model\model.js:      console.log(name, type);
+    addon\-private\system\model\states.js:      console.log("Received myEvent with", param);
+    addon\-private\system\record-arrays\adapter-populated-record-array.js:    console.log(admins.get("length")); // 42
+    addon\-private\system\record-arrays\adapter-populated-record-array.js:    console.log(admins.get("length")); // 123
+    addon\-private\system\store.js:      console.log(`Currently logged in as ${username}`);
+    addon\-private\system\store.js:      console.log(user); // null
+    benchmarks\config.js:    // { key: "stats.store.modelFor", name: 'modelFor', transform: function(t, c) { console.log(t); return t; }, rollup: false },
+    node-tests\nodetest-runner.js:  console.log('Verifing `.only` in tests');
+    node-tests\nodetest-runner.js:    console.log('No `.only` found');
+    tests\test-helper.js:      Ember.Logger.log(reason, reason.stack);
+
+Really useful URL: https://emberobserver.com/code-search?codeQuery=Ember.Logger
+Results:
+    191 Add-Ons use Ember.Logger.
+    Notables:
+        ember-source (19 usages)
+        ember-concurrency (15 usages)
+        ember-stripe-service (9 usages)
+        ember-cli-page-object (4 usages) 
+        ember-data (3 usages)
+        ember-cli-fastboot (1 usage)
+        ember-i18n (1 usage)
+        ember-simple-auth-token (1 usage)
+        ember-svg-jar (1 usage)
+        liquid-fire (1 usage)
+
+Preparation for writing this section:
+
+0. Read the source of Ember.Logger and enumerate the methods, understanding any corner cases they may raise for replacement with console commands. [Done]
+
+ember-console exports assert, debug, error, info, log, warn.
+Chrome, Firefox, Edge, IE11, Safari support all of these.
+Node 6 supports all of them except debug, which doesn't appear until Node 9.x.
+
+So the only thing even remotely edgy surrounds what to do with Logger.debug(). The current implementation checks if console supports debug and either issues console.debug() or console.log() accordingly.
+
+1. Mentally implement the deprecation itself on each method and enumerate the likely fallout, if any. [Done]
+
+The mechanism that reports deprecations uses these calls, so we would need that code to call the console directly before we attempted to flag these calls for deprecation. In fact, we would probably want to replace all eight of the internal usages.
+
+A number of tests redefine Ember.Logger temporarily as a means of interception. If all of those uses are going to console, it should still be possible to redirect those, but it may make debugging uncomfortable.
+
+2. Mentally implement the codemod to replace Ember.Logging calls with console calls. Understand what will be easy or difficult.
+
+I have real doubts about my ability to do this - especially if it involves familiarity with ASTs - but it could be an opportunity to learn.
+
+3. Enumerate the places in the emberjs source that call Ember.Logger and its methods. Get a feeling for how many do and what methods they use a lot of. [Done]
+
+4. Research any Babel plugins which remove console calls.
+

--- a/text/0297-deprecate-ember-logger.md
+++ b/text/0297-deprecate-ember-logger.md
@@ -1,6 +1,6 @@
 - 2018-01-17
 - RFC PR: 0297
-- Ember Issue: (leave this empty)
+- Ember Issue: https://github.com/emberjs/ember.js/issues/16231
 
 # Deprecation of Ember.Logger
 

--- a/text/0297-deprecate-ember-logger.md
+++ b/text/0297-deprecate-ember-logger.md
@@ -75,8 +75,13 @@ affect this behavior.
 ### Codemod 
 
 Provide a codemod that developers can use to switch references to the methods 
-of `Ember.Logger` to use the corresponding `console` methods instead. I 
-will definitely need help here.
+of `Ember.Logger` to use the corresponding `console` methods instead. 
+
+The codemod will need to replace `Ember.Logger.debug` calls with `(console.debug || 
+console.log)(<arguments>)` or something similar to take in stride the situation 
+where console.debug isn't defined.
+
+I will definitely need help here.
 
 ### Add-On Developers
 
@@ -162,29 +167,4 @@ a shim for users.
 
 ## Unresolved questions
 
-### How do we deal with `Logger.debug` in the codemod? 
-
-Do we provide separate options for those who might use Node versions 
-earlier than 9 and those who are confident they will only use Node 
-version 9 or later? 
-
-Do we have the codemod inject a polyfill for `console.debug` that calls 
-`console.log`? 
-
-Do we provide one separately for the user to apply? 
-
-Or does that become a fastboot concern, since that's the primary driver 
-for running ember projects in node?
-
-### What do we do about the eslint `no-console` flag? 
-
-Some developers are using `Ember.Logger` right now to work around it, while 
-others are providing their own logging service, and others are just providing 
-override comments. 
-
-Currently, `no-console` is in the default set of flags set with eslint, 
-and ember-cli doesn't override the defaults in its set of flags to turn it off. 
-
-Should we turn it off in the ember-cli settings? Or should that be left as a user decision? 
-
-I'm inclined toward the latter. 
+None at this point. The answers from prior drafts have been promoted into the text. 

--- a/text/0297-deprecate-ember-logger.md
+++ b/text/0297-deprecate-ember-logger.md
@@ -1,5 +1,5 @@
 - 2018-01-17
-- RFC PR: (leave this empty)
+- RFC PR: 0297
 - Ember Issue: (leave this empty)
 
 # Deprecation of Ember.Logger

--- a/text/0297-deprecate-ember-logger.md
+++ b/text/0297-deprecate-ember-logger.md
@@ -26,19 +26,10 @@ lighter.
 
 For the most part, this is a 1:1 substitution of the global `console` object 
 for `Ember.Logger`. However, Node only added support for `console.debug` in 
-Node version 9. To support earlier versions of Node, our codemod will need to 
-use `console.log`, rather than `console.debug`, as the replacement for 
-`Logger.debug`, except for add-ons that specify that they only support Node 
-version 9 and beyond.
-
-When a project is built for production, `Ember.Logger` calls become a no-op. 
-Replacing `Ember.Logger` calls with console calls will require some other 
-mechanism to suppress logging in production builds. Fortunately, the 
-`babel-plugin-transform-remove-console` will suppress console 
-interaction, a far more comprehensive solution than relying upon
-`Ember.logger`. We will need to supply instructions for setting this up (for
-production builds only) in the `ember-cli` Broccoli pipeline.
-
+Node version 9. If we wish to support earlier versions of Node, our codemod 
+will need to use `console.log`, rather than `console.debug`, as the 
+replacement for `Logger.debug`. For users who don't care about Node or are 
+specifying Node version 9 as their minimum, we could use `console.debug`.
 
 ### Within the framework
 
@@ -70,9 +61,15 @@ Note: None of the uses of `Ember.Logger` in `ember.js` or `ember-data` involve
 `Ember.debug`, so that issue doesn't affect the Ember.js code directly.
 
 Add deprecation warnings to the implementation: `ember-console\lib\index.js`.
-Bear in mind that the deprecation mechanism currently calls `Logger.warn`, so 
-that code should be changed _first_ or this change will be very difficult 
-to debug.
+Bear in mind that the deprecation mechanism in `ember-debug` currently calls 
+`Logger.warn`, so the `ember-debug` code should be changed _first_ or adding 
+the deprecation warning will create a deep recursion.
+
+The log and debug messages emitted by Ember for deprecations and assertions 
+are not emitted on production. However, this is because they are suppressed 
+by the ember-debug module, which currently consumes `Ember.Logger`, _not_ 
+by `Ember.Logger` itself. Hence, replacing calls to `Ember.Logger` with 
+direct calls to the console will not affect this behavior. 
 
 ### Codemod 
 
@@ -125,15 +122,9 @@ from the Super Rentals tutorial, and anywhere else it appears on the website.
 Once it is gone from the code, we also need to verify it no longer appears in 
 the API listings. 
 
-We must supply instructions for using `babel-plugin-transform-remove-console`
-in `ember-cli` so it is only applied in production builds.
-
 We must provide an entry in the deprecation guide for this change:
 * offering instruction for using the codemod to perform the change automatically
 with before and after code samples.
-* documenting the use of `babel-plugin-transform-remove-console` in the 
-`ember-cli` build to suppress console calls in production.
-the console calls in production code. 
 * describing the issue with using console.debug on node versions 
 earlier than Node 9 and what provision the codemod has made to deal with it.
 * describing alternative ways of dealing with eslint's `no-console` messages.
@@ -170,15 +161,24 @@ a shim for users.
 
 ## Unresolved questions
 
-How do we deal with `Logger.debug` in the codemod? Do we provide separate 
-options for those who might use Node versions earlier than 9 and those who 
-are confident they will only use Node version 9 or later? Do we have the 
-codemod inject a polyfill for console.debug that calls console.log? Do we
-provide one separately for the user to apply? Or does that become a fastboot 
-concern, since that's the primary driver for running ember projects in node.
+How do we deal with `Logger.debug` in the codemod? 
+* Do we provide separate options for those who might use Node versions 
+earlier than 9 and those who are confident they will only use Node 
+version 9 or later? 
+* Do we have the codemod inject a polyfill for `console.debug` that calls 
+`console.log`? 
+* Do we provide one separately for the user to apply? 
+* Or does that become a fastboot concern, since that's the primary driver 
+for running ember projects in node?
 
-What do we do about the eslint `no-console` flag? Some developers are 
-using `Ember.Logger` right now to work around it. Others are providing 
-their own logging service. If we encourage the use of a Babel plugin 
-to strip console calls, should we remove `no-console` from the default 
-flags that `ember-cli` ships?
+What do we do about the eslint `no-console` flag? 
+
+* Some developers are using `Ember.Logger` right now to work around it, 
+  while others are providing their own logging service, and others are just
+  providing override comments. 
+* Currently, `no-console` is in the default set of flags set with eslint, 
+and ember-cli doesn't override the defaults in its set of flags to turn it off. 
+* Should we turn it off in the ember-cli settings? 
+* Or should that be left as a user decision? 
+
+I'm inclined toward the latter. 

--- a/text/0297-deprecate-ember-logger.md
+++ b/text/0297-deprecate-ember-logger.md
@@ -61,15 +61,16 @@ Note: None of the uses of `Ember.Logger` in `ember.js` or `ember-data` involve
 `Ember.debug`, so that issue doesn't affect the Ember.js code directly.
 
 Add deprecation warnings to the implementation: `ember-console\lib\index.js`.
-Bear in mind that the deprecation mechanism in `ember-debug` currently calls 
+Bear in mind that `Ember.deprecate` in `ember-debug` currently calls 
 `Logger.warn`, so the `ember-debug` code should be changed _first_ or adding 
 the deprecation warning will create a deep recursion.
 
-The log and debug messages emitted by Ember for deprecations and assertions 
-are not emitted on production. However, this is because they are suppressed 
-by the ember-debug module, which currently consumes `Ember.Logger`, _not_ 
-by `Ember.Logger` itself. Hence, replacing calls to `Ember.Logger` with 
-direct calls to the console will not affect this behavior. 
+The `Ember.assert`, `Ember.warn`, `Ember.info`, `Ember.debug`, and 
+`Ember.deprecate` methods suppress their output on production builds. 
+However, they are suppressing them in the `ember-debug` module, which 
+currently consumes `Ember.Logger`, _not_ by `Ember.Logger` itself. Hence, 
+replacing calls to `Ember.Logger` with direct calls to the console will not 
+affect this behavior. 
 
 ### Codemod 
 
@@ -143,8 +144,8 @@ twenty of those add-ons have more than six references to `Ember.Logger`.
 If this is characteristic of the user base, the level of effort to make 
 the change, even by hand, should be very small for most users.
 
-Those using `Logger.debug` as something different from `Logger.log`may have at 
-least a theoretical concern. Under the covers `Logger.debug` only calls 
+Those using `Logger.debug` as something different from `Logger.log` may have 
+at least a theoretical concern. Under the covers `Logger.debug` only calls 
 `console.debug` if it exists, calling `console.log` otherwise. The only 
 platform where the difference between the two is visible in the console is on 
 Safari. We can encourage folks with a tangible, practical concern about this to
@@ -161,24 +162,29 @@ a shim for users.
 
 ## Unresolved questions
 
-How do we deal with `Logger.debug` in the codemod? 
-* Do we provide separate options for those who might use Node versions 
+### How do we deal with `Logger.debug` in the codemod? 
+
+Do we provide separate options for those who might use Node versions 
 earlier than 9 and those who are confident they will only use Node 
 version 9 or later? 
-* Do we have the codemod inject a polyfill for `console.debug` that calls 
+
+Do we have the codemod inject a polyfill for `console.debug` that calls 
 `console.log`? 
-* Do we provide one separately for the user to apply? 
-* Or does that become a fastboot concern, since that's the primary driver 
+
+Do we provide one separately for the user to apply? 
+
+Or does that become a fastboot concern, since that's the primary driver 
 for running ember projects in node?
 
-What do we do about the eslint `no-console` flag? 
+### What do we do about the eslint `no-console` flag? 
 
-* Some developers are using `Ember.Logger` right now to work around it, 
-  while others are providing their own logging service, and others are just
-  providing override comments. 
-* Currently, `no-console` is in the default set of flags set with eslint, 
+Some developers are using `Ember.Logger` right now to work around it, while 
+others are providing their own logging service, and others are just providing 
+override comments. 
+
+Currently, `no-console` is in the default set of flags set with eslint, 
 and ember-cli doesn't override the defaults in its set of flags to turn it off. 
-* Should we turn it off in the ember-cli settings? 
-* Or should that be left as a user decision? 
+
+Should we turn it off in the ember-cli settings? Or should that be left as a user decision? 
 
 I'm inclined toward the latter. 


### PR DESCRIPTION
This is the RFC for the work to deprecate Ember.Logger.

[Rendered](https://github.com/lupestro/rfcs/blob/lupestro-deprecate-logger/text/0297-deprecate-ember-logger.md).