### PR TITLE
RFC: Ember 2018 Roadmap

### DIFF
--- a/text/0000-roadmap-2018.md
+++ b/text/0000-roadmap-2018.md
@@ -1,0 +1,147 @@
+# Ember 2018 Roadmap RFC
+
+# Summary
+
+This RFC sets the Ember 2018 Roadmap. This year’s goals are to:
+
+- Improve communication and streamline decision-making, and empower new leaders.
+- Finish the major initiatives that we’ve already started.
+- Ship a new *edition*, Ember Octane, focused on performance and productivity.
+
+# Motivation
+
+This document is a distillation of multiple sources:
+
+1. The 2018 Community Survey.
+2. Community #EmberJS2018 blog posts, authored in response to our call for posts.
+3. Discussion on https://discuss.emberjs.com
+4. Deliberations among the Ember core teams.
+
+The goal of the RFC is to align the Ember community around a set of shared, achievable goals that balance the needs of existing users with the need to grow and support new use cases.
+
+# Detailed design
+
+This year is primarily about finishing initiatives that we’ve already started, fine-tuning our communication channels, and getting the world excited about Ember.
+
+- **Improve communication and streamline decision-making**. We will expand and refine the core team structure, to ensure decisions are made quickly, communication is clear, and users feel empowered to become contributors. We will invest in mentoring new leaders, and cross-pollinating knowledge between teams. As a community, we will share our excitement about Ember with the wider web development world.
+- **Finish what we started.** We need to focus on stabilizing and polishing the work that we’ve already started in 2018. We will add extension points to allow popular new tools to be quickly adopted in Ember apps. We will standardize around ES modules and npm packages, better enabling the sharing of Ember tools with the wider JavaScript community.
+- **Ship Ember Octane**. We will ship a new *edition* of Ember, emphasizing its *modern productivity and performance*. We will polish our compatibility with new JavaScript language features like native classes, decorators, and async functions. We will continue efforts like optional jQuery and treeshaking that reduce file size. We will overhaul the Ember homepage to align with Octane and tell the story of modern Ember.
+
+To help us deliver a polished, cohesive experience, we will focus on two end-to-end, real world use cases. Having concrete use cases in mind helps us improve our marketing as well as prioritize feature development. In 2018, our two use cases are:
+
+- **Productivity apps.** Ember’s historical strength: sophisticated, highly interactive apps that users spend a lot of time in, getting things done.
+- **Content apps**, where pages are text-heavy and where the first load is critical. In performance-constrained environments, Ember’s strong conventions can help developers build faster apps by default.
+
+## Improve communication and streamline decision-making
+
+> Silence is the only thing that cause developers to lose trust in Ember. And overcommunication is the cure to silence.
+> —[Ryan Toronto and Sam Selikoff](https://embermap.com/notes/107-our-wish-for-ember-in-2018-overcommunication)
+
+> Technical leadership seems to me to be about 10% technical brilliance and 90% clear communication. We have loads of technical brilliance; we need more communication!
+> —[Chris Krycho](https://www.chriskrycho.com/2018/emberjs2018-part-3.html)
+
+> Communication is well, not stellar. Newsletters do a great job at communicating what already happened, but future plans are largely unknown to public.
+> —[V. Lascik](https://medium.com/@vlascik/honest-look-at-ember-in-the-middle-of-2018-a0dc2787e506)
+
+> The Core Team is in a unique position to add external-facing commentary on the framework's vision. Our RFC process and release posts are awesome, and they have done great things internally, so I would like to encourage Core to look outwards next.
+> —[Jen Weber](https://gist.github.com/jenweber/a9fbea98478fc3841fb8b24f7dc961c8)
+
+> My hope is that Ember will continue to be an investment worth making. I see a growing, diverse community with lots of fresh faces as an essential part of that. 
+> —[Matt McManus](https://medium.com/@mattmcmanus/emberjs2018-2d28a441fadb)
+
+> Finding how and where I can help feels scattered. Issues do not receive effective labeling. This has translated into me not contributing to varying projects.
+> —[Eli Flanagan](https://www.innovu.com/2018/05/a-few-quick-thoughts-on-ember-for-2018-from-a-corporate-citizen/)
+
+> What I’d wish for Ember’s 2018 Roadmap though is to find ways to lower the entry barriers for newcomers to get started in their attempt to advocate Ember and to be creative on how to encourage a sense of empowerment in the wider community regarding outreach efforts.
+> —[Jessica Jordan](https://simplabs.com/blog/2018/05/30/a-little-encouragement-goes-a-long-way-in-2018.html)
+
+> My hope is that we will continue to hand off the baton of the community values to developers who are new to Ember.
+> —[Bill Heaton](https://pixelhandler.com/posts/emberjs2018-a-few-suggestions)
+
+> A good idea would be to continue creating quests for small things like documentation, code-cleaning… And maybe add a place where this quest can be found
+> —[Benjamin Jegard](https://medium.com/@KamiKillertO/my-emberjs-in-2018-bc7f52739e16)
+
+There has never been more time and energy going into Ember, but we’ve heard loud and clear that this momentum is not as visible as it needs to be. We are going to do a few things to fix this.
+
+- **Continue to expand and refine the team structure**, breaking up work and delegating it to strike teams or new core teams as appropriate
+- **Move to discoverable communication tools**, such as our Discourse forum, that don’t lose history and are visible to search engines.
+- **Automate communication.** For example, we will improve the [Statusboard](https://www.emberjs.com/statusboard) to automatically pull data from GitHub.
+- **Document “best practices” for core teams**, spreading knowledge about what works and what doesn’t for building an active community.
+- **Invest in mentoring**, both through more contributor documentation as well as direct mentorship relationships.
+
+## Finish what we started
+
+> The last few years have seen the Ember team do a lot of really important exploratory work, including projects like [Glimmer.js](https://glimmerjs.com/); and we have landed some of the initiatives we have started. But I think it’s fair to say that focus has not been our strong suit. It’s time for a year of shipping.—[Chris Krycho](https://www.chriskrycho.com/2018/emberjs2018-part-1.html)
+
+> I think the goal of being able to just npm install or yarn install any package and having it "just work" should be high on the TODO list.
+> —[Andrew Callahan](http://andrewcallahan.com/a-road-to-ember-4-0/)
+
+> When [Yehuda Katz](https://mobile.twitter.com/wycats) [closed](https://github.com/emberjs/rfcs/pull/38#issuecomment-355800759) that RFC, I think a bit of that dream died, but at the same time I was happy. Not because it wasn't going to happen but because there was clear communication, finally.
+> —[Ilya Radchenko](https://burstcreations.com/ember-in-2018-and-beyond/)
+
+> I firmly believe that Ember needs to deliver all the great new features that are currently in flight before taking more to its plate.
+> —[Josemar Luedke](https://josemarluedke.com/blog/ember-in-2018-getting-ready-for-the-next-major-release/)
+
+This year, we **need a strong focus on shipping**. Huge improvements to Ember have either already landed or are in the pipeline. We need to cross the finish line on these before moving on to new initiatives, however important or exciting they might seem.
+
+“Done” doesn’t mean behind a feature flag on canary. Finishing what we started means ensuring that features are discoverable, on by default, and that the guides and other documentation have been revised to take them into account. It means making sure they work well with the entire Ember ecosystem so that new developers get a seamless experience.
+
+This year, we are going to ship:
+
+- **Broccoli 2.0** in Ember CLI, as well as significant investment into Broccoli documentation, marketing and advocacy.
+- **Module Unification** as the default file system layout.
+- **Glimmer Components** as the default component API.
+- **Native JavaScript classes** as the default object model.
+- **Native JavaScript modules,** including:
+  - **Exposing modules in the build pipeline** and allowing addons to integrate tools like Parcel, Rollup or Webpack.
+  - **Publishing Ember as npm packages**.
+  - **Importing npm packages** into your Ember apps with zero additional configuration. (This was, far and away, the most-mentioned feature request in all of the #EmberJS2018 blog posts.)
+
+## Ember Octane
+
+> The homepage looks a bit outdated and does not a very compelling job at selling Ember to new users, IMHO. This needs to change.
+> —[Simon Ihmig](https://www.kaliber5.de/en/blog/ember-js-in-2018-get-better-at-marketing/)
+
+> When you generate a project with `ember new`, you get a project that is almost “legacy” by standards of the wider JavaScript community.
+> —[Gaurav Munjal](https://medium.com/@gauravmunjal_86037/stability-without-stagnation-in-2018-ce2d4f519991)
+
+> Ember's custom object model isn't hard to learn, but it's a big reason people are turned off before learning why Ember is such a great choce. I'd like to see ES classes support finished and adopted in the Guides ASAP, followed by decorators.
+> —[Michael Kaiser-Nyman](https://gist.github.com/michaelrkn/ffdd67906a724362bd8f5ccc3434db0f)
+
+> ES6 syntax, the new file layout, new templating etc. — the new features will land in 3.x releases as non-breaking changes, but let’s prepare to show off the sum of all those amazing parts. Sell the vision, right now! A ‘relaunch’ of Ember in the minds of those who dismiss it.
+> —[Will Viles](https://medium.com/@willviles/ember-js-in-2018-lets-market-the-future-e6be9c42cf86)
+
+Ember releases a new, stable version every six weeks. For existing users, this drumbeat of incremental improvement is easier to keep up with than splashy, big-bang releases.
+
+However, for people not following Ember closely, it’s easy to miss the significant improvements that happen over time. As detailed in the forthcoming Ember Editions RFC (being worked on by [Dave Wasmer](https://twitter.com/davewasmer)), every year or so **we will release a new edition of the Ember**, focused on a particular theme. The set of improvements related to that theme, taken together, mark a meaningful change to how people should think about Ember.
+
+In 2018, we will release the first edition of Ember, called *Ember Octane*. **Octane will focus on the themes of productivity and performance.** We’ll talk about how Ember excels in performance-constrained environments, particularly on mobile devices, as well as the productivity benefits of modern JavaScript features like classes, decorators, and async functions when paired with Ember’s strong conventions and community.
+
+This is also a good time for us to review the new application blueprint, to ensure that it is up-to-date with the latest Ember Octane idioms and includes the right set of addons to help new users achieve our goals of productivity and performance.
+
+Ember Octane is about *doing more with less*. Not only does this make Ember simpler to learn, it makes the framework smaller and faster, too. These are some of the highlights of Ember Octane:
+
+- **No jQuery.** Currently available as an optional feature, we will enable this by default.
+- **Svelte builds**, where deprecated features are stripped out of framework code. We will get more aggressive about deprecating code that is not widely used.
+- **Native JavaScript classes** perform better and require less code, and integrate better with tools like TypeScript and ESLint.
+- **Glimmer components** offer a greatly simplified API and remove common slow paths.
+- **Incremental rendering and rehydration** that keeps even low-end devices responsive as the application boots.
+- **Treeshaking** to automatically remove code unused by the application.
+- **Eliminating the runloop** from the programming model, replaced by `async` and `await` in tests.
+
+The final timeline and feature set of Ember Octane will be determined by the core teams and are not set in stone in this RFC.
+
+In keeping with our commitment to finishing what we’ve started, these are all features that are either finished or being implemented now. We should not plan for Octane to have any features that are not already close to being done today, so that we have adequate time to make sure they all work well together as part a cohesive programming model.
+
+The process of releasing a new edition also gives us an opportunity to evaluate what it’s like to use Ember end-to-end. We will overhaul the Ember homepage, focusing on Ember Octane and how it helps solve targeted use cases.
+
+This is also a good time to perform a holistic review of the guides, making sure that examples use the latest idioms and set new learners on a good path.
+
+# Non-goals
+
+One of our most important goals this year is to focus on shipping. Focus means saying “no” to ideas that we really like.
+
+- **Major new Ember Data features**. We will instead focus our efforts on stabilizing Ember Data and updating it to align better with Ember Octane idioms.
+- **Significant work on Glimmer.js**. We will instead focus on our efforts on incorporating the lessons of Glimmer.js into work that enables a smaller core in Ember.
+- **Further Glimmer VM optimizations**. Glimmer performance is industry leading and not a bottleneck in most Ember.js apps. At this point, the Ember.js payload is the primary performance bottleneck, and we should turn our attention to enabling better performance there.
+- **Brand new language features** in either Handlebars templates or Ember’s JavaScript files. There is already a full pipeline of features, such as Glimmer components, JavaScript classes with decorators, and module unification that we need to finish before starting any new major design.

--- a/text/0000-roadmap-2018.md
+++ b/text/0000-roadmap-2018.md
@@ -121,7 +121,7 @@ This year, we are going to ship:
 
 Ember releases a new, stable version every six weeks. For existing users, this drumbeat of incremental improvement is easier to keep up with than splashy, big-bang releases.
 
-However, for people not following Ember closely, it’s easy to miss the significant improvements that happen over time. As detailed in the forthcoming Ember Editions RFC (being worked on by [Dave Wasmer](https://twitter.com/davewasmer)), every year or so **we will release a new edition of the Ember**, focused on a particular theme. The set of improvements related to that theme, taken together, mark a meaningful change to how people should think about Ember.
+However, for people not following Ember closely, it’s easy to miss the significant improvements that happen over time. As detailed in the forthcoming Ember Editions RFC (being worked on by [Dave Wasmer](https://twitter.com/davewasmer)), every year or so **we will release a new edition of Ember**, focused on a particular theme. The set of improvements related to that theme, taken together, mark a meaningful change to how people should think about Ember.
 
 In 2018, we will release the first edition of Ember, called *Ember Octane*. **Octane will focus on the themes of productivity and performance.** We’ll talk about how Ember excels in performance-constrained environments, particularly on mobile devices, as well as the productivity benefits of modern JavaScript features like classes, decorators, and async functions when paired with Ember’s strong conventions and community.
 

--- a/text/0000-roadmap-2018.md
+++ b/text/0000-roadmap-2018.md
@@ -136,6 +136,7 @@ Ember Octane is about *doing more with less*. Not only does this make Ember simp
 - **Incremental rendering and rehydration** that keeps even low-end devices responsive as the application boots.
 - **Treeshaking** to automatically remove code unused by the application.
 - **Eliminating the runloop** from the programming model, replaced by `async` and `await` in tests.
+- **Stabilizing Ember Data** by streamlining internals and providing more extension points for applications and addons to customize behavior.
 
 The final timeline and feature set of Ember Octane will be determined by the core teams and are not set in stone in this RFC.
 
@@ -149,7 +150,6 @@ This is also a good time to perform a holistic review of the guides, making sure
 
 One of our most important goals this year is to focus on shipping. Focus means saying “no” to ideas that we really like.
 
-- **Major new Ember Data features**. We will instead focus our efforts on stabilizing Ember Data and updating it to align better with Ember Octane idioms.
 - **Significant work on Glimmer.js**. We will instead focus on our efforts on incorporating the lessons of Glimmer.js into work that enables a smaller core in Ember.
 - **Further Glimmer VM optimizations**. Glimmer performance is industry leading and not a bottleneck in most Ember.js apps. At this point, the Ember.js payload is the primary performance bottleneck, and we should turn our attention to enabling better performance there.
 - **Brand new language features** in either Handlebars templates or Ember’s JavaScript files. There is already a full pipeline of features, such as Glimmer components, JavaScript classes with decorators, and module unification that we need to finish before starting any new major design.

--- a/text/0000-roadmap-2018.md
+++ b/text/0000-roadmap-2018.md
@@ -61,13 +61,21 @@ To help us deliver a polished, cohesive experience, we will focus on two end-to-
 > A good idea would be to continue creating quests for small things like documentation, code-cleaning… And maybe add a place where this quest can be found
 > —[Benjamin Jegard](https://medium.com/@KamiKillertO/my-emberjs-in-2018-bc7f52739e16)
 
-There has never been more time and energy going into Ember, but we’ve heard loud and clear that this momentum is not as visible as it needs to be. We are going to do a few things to fix this.
+There has never been more time and energy going into Ember, but we’ve heard loud and clear that this momentum is not as visible as it needs to be. We are going to prioritize sharing work as it happens, making planning and status updates more discoverable, and making it easier for would-be contributors to get involved. 
 
-- **Continue to expand and refine the team structure**, breaking up work and delegating it to strike teams or new core teams as appropriate
-- **Move to discoverable communication tools**, such as our Discourse forum, that don’t lose history and are visible to search engines.
-- **Automate communication.** For example, we will improve the [Statusboard](https://www.emberjs.com/statusboard) to automatically pull data from GitHub.
+We also need to double down on making Ember as friendly and inclusive as possible, particularly for folks who have never participated in an open source project before. As we bring in new community members, we will make changes to ensure that individuals can have a meaningful impact, no matter what time zone they live in.
+
+Lastly, we need to make sure that our core teams are not so bogged down that they become a bottleneck for decision-making. Core teams and strike teams decentralize planning, empower new contributors to take ownership of community initiatives, and help to build and strengthen relationships among community members. We will invest in improving the organization and structure of these teams this year.
+
+To accomplish these goals, this year we will:
+
+- **Expand and refine our team structure**, breaking up work and delegating it to strike teams or new core teams as appropriate.
+- **Move to discoverable communication tools**, such as our Discourse forum, which is visible to search engines, and Discord chat, which doesn't lose history.
+- **Invest in mentoring**. This includes direct mentorship relationships, as well as written guides like quest issues that are helpful even for people in different time zones or who have difficulty with spoken English.
+- **Track RFC implementation via GitHub issues**, so it's clear what the next steps are after an RFC is merged.
+- **Automate communication and status updates.** For example, we will improve the [Statusboard](https://www.emberjs.com/statusboard) to automatically pull from RFCs and RFC tracking issues.
 - **Document “best practices” for core teams**, spreading knowledge about what works and what doesn’t for building an active community.
-- **Invest in mentoring**, both through more contributor documentation as well as direct mentorship relationships.
+- **Unify the RFC process** to ensure a consistent experience across all of Ember's sub-projects.
 
 ## Finish what we started
 


### PR DESCRIPTION
This RFC sets the Ember 2018 Roadmap. This year’s goals are to:

- Improve communication and streamline decision-making, and empower new leaders.
- Finish the major initiatives that we’ve already started.
- Ship a new *edition*, Ember Octane, focused on performance and productivity.

A sincere thank you to everyone who tweeted, posted in the forum, and wrote responses to the #EmberJS2018 call for blog posts. We were blown away by the outpouring of thoughtful, insightful feedback.

One note about the time period. We intend for this 2018 roadmap to cover the time period from now until around March 2019, to coincide with EmberConf. Our goal is to continue this process on an annual basis.

[Rendered](https://github.com/tomdale/rfcs/blob/2018-roadmap/text/0000-roadmap-2018.md)