### PR TITLE
An alternative to Controllers

### DIFF
--- a/text/0000-controller-migration-path.md
+++ b/text/0000-controller-migration-path.md
@@ -271,19 +271,6 @@ export function parseError(error: any): ParsedError {
 ```
 
 
-## How we teach this
-
-> What names and terminology work best for these concepts and why? How is this
-idea best presented? As a continuation of existing Ember patterns, or as a
-wholly new one?
-
-> Would the acceptance of this proposal mean the Ember guides must be
-re-organized or altered? Does it change how Ember is taught to new users
-at any level?
-
-> How should this feature be introduced and taught to existing Ember
-users?
-
 ## Drawbacks
 
 These changes would require many changes to existing apps, and there likely won't be an ability to codemod people's code to the new way of doing things. This could greatly slow down the migration, or have people opt to not migrate at all. It's very important that every use case for controllers today _can_ be implemented using the aforementioned techniques. If people are willing to share their controller scenarios, we can provide a library of examples of translation so that others may migrate more quickly.

--- a/text/0000-controller-migration-path.md
+++ b/text/0000-controller-migration-path.md
@@ -236,6 +236,7 @@ Given a visit to `/posts`
 2. lookup a component named "posts", `component:posts` and `template:components/posts`.   
   NOTE: if the `template:posts` template was found, this step does not happen.  
   a. this component is invoked _as if_ `template:posts` was defined as `<Posts @model={{this.model}} />`
+3. default to `{{outlet}}` for sub routes
 
 ## Drawbacks
 

--- a/text/0000-controller-migration-path.md
+++ b/text/0000-controller-migration-path.md
@@ -236,7 +236,7 @@ Given a visit to `/posts`
 2. lookup a component named "posts", `component:posts` and `template:components/posts`.   
   NOTE: if the `template:posts` template was found, this step does not happen.  
   a. this component is invoked _as if_ `template:posts` was defined as `<Posts @model={{this.model}} />`
-3. default to `{{outlet}}` for sub routes
+3. default to `{{outlet}}` or `{{yield}}` for sub routes
 
 ## Drawbacks
 

--- a/text/0000-controller-migration-path.md
+++ b/text/0000-controller-migration-path.md
@@ -29,6 +29,13 @@ This'll explore how controllers are used and how viable alternatives can be for 
 
 ## Detailed design
 
+### Query Params
+
+In this other RFC that [proposes adding a @queryParam decorator and service to manage query params](https://github.com/emberjs/rfcs/pull/380), query-param management would be pulled out of the controller entirely.
+
+### Error and Loading States
+
+
 > This is the bulk of the RFC.
 
 > Explain the design in enough detail for somebody

--- a/text/0000-controller-migration-path.md
+++ b/text/0000-controller-migration-path.md
@@ -239,6 +239,17 @@ Given a visit to `/posts`
   - this component is invoked _as if_ `template:posts` was defined as `<Posts @model={{this.model}} />`
 - default to `{{outlet}}` or `{{yield}}` for sub routes
 
+## How we teach this
+
+Since this is a new programming paradigm, we'll want to update the guides and tutorials to reflect a new "happy path".
+ - Remove most mentions of controllers in the guides / tutorials. maybe just leave the bare informational "what controllers are", at least until a deprecation can be figured out.
+ - Swap out the controllers page in the guides for a page that shows examples of how a component is chosen to be the entry point / outlet of the route. Additionally on this page, it should mention that there can be an optional template (like we have today) that receives the `@model` argument that takes priority over any component with the same name as the route and without any template at all, it's just an `{{outlet}}` for subroutes. 
+ 
+    The controllers page for octane has already moved under routing, so talking about just rendering behavior should make things feel simpler.
+    
+ - There is already a separate guides page for query params. Query params should remain on their own page, but just be updated to use the `@queryParam` decorator, as described in [RFC 380](https://github.com/emberjs/rfcs/pull/380)
+
+
 ## Drawbacks
 
 It's very important that every use case for controllers today _can_ be implemented using the aforementioned techniques. If people are willing to share their controller scenarios, we can provide a library of examples of translation so that others may migrate more quickly.

--- a/text/0000-controller-migration-path.md
+++ b/text/0000-controller-migration-path.md
@@ -173,7 +173,7 @@ Given a visit to `/posts`
   - this component is invoked _as if_ `template:posts` was defined as `<Posts @model={{this.model}} />`
 - default to `{{outlet}}` or `{{yield}}` for sub routes
 
-**NOTE** as a side effect of treating the default template in this manner, it would become a requirement, in order to maintain cohesion, that we treat loading and error templates similar to the above lookup rules. This means that loading and error components can be used with service injections, and other state.
+**NOTE** as a side effect of treating the default template in this manner, it would become a requirement, in order to maintain cohesion, that we treat loading and error templates similar to the above lookup rules. This means that loading and error components can be used with service injections, and other state. The error template currently receive a `this.model`, but that will be changed to `@error` for components and be the error that caused the error template/component to render (existing behavior will not be changed)`
 
 ## How we teach this
 

--- a/text/0000-controller-migration-path.md
+++ b/text/0000-controller-migration-path.md
@@ -233,6 +233,7 @@ Given a visit to `/posts`
 - lookup `template:posts`  
   - if a controller exists, the template will be rendered as it is today.  
   - if a controller does not exist, a template-only component will be assumed, passing the `@model` argument. This will make interop between controllers' templates and template-only component / used-for-route template components inconsistent, so controllers' templates should also get a `@model` argument.
+  - if a component by the same name exists, it is ignored and must be invoked manually.
 - lookup a component named "posts", `component:posts` and `template:components/posts`.   
   NOTE: if the `template:posts` template was found, this step does not happen.  
   - this component is invoked _as if_ `template:posts` was defined as `<Posts @model={{this.model}} />`

--- a/text/0000-controller-migration-path.md
+++ b/text/0000-controller-migration-path.md
@@ -1,0 +1,70 @@
+- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- Relevant Team(s): (fill this in with the [team(s)](README.md#relevant-teams) to which this RFC applies)
+- RFC PR: (after opening the RFC PR, update this with a link to it and update the file name)
+- Tracking: (leave this empty)
+
+# Migration away from controllers
+
+## Summary
+
+ - Provide alternative APIs that encompass existing behavior currently implemented by controllers.
+ - Out of scope:
+   - Deprecating and eliminating controllers -- but the goal of this RFC is to provide a path to remove controllers from Ember altogether. 
+ - Not Proposing
+   - Adding the ability to access more properties than `model` from the route template
+   - Adding the ability to invoke actions on the route.
+   
+This'll explore how controllers are used and how viable alternatives can be for migrating away from controllers so that they may eventually be removed.
+
+## Motivation
+
+ - Many were excited about [Routable Components](https://github.com/ef4/rfcs/blob/routeable-components/active/0000-routeable-components.md).
+ - Many agree that controllers are awkward, and should be considered for removal (as mentioned in many #EmberJS2019 Roadmap blogposts).
+ - There is, without a doubt, some confusion with respect to controllers:
+   - should actions live on controllers?
+   - how are they different from components?
+   - controllers may feel like a route-blessed component (hence the prior excitement over the Routable-Components RFC)
+   - controllers aren't created by default during `ember g route my-route`, so there is a learning curve around the fact that route templates can't access things on the route, and must create another new file, called a controller.
+
+
+## Detailed design
+
+> This is the bulk of the RFC.
+
+> Explain the design in enough detail for somebody
+familiar with the framework to understand, and for somebody familiar with the
+implementation to implement. This should get into specifics and corner-cases,
+and include examples of how the feature is used. Any new terminology should be
+defined here.
+
+## How we teach this
+
+> What names and terminology work best for these concepts and why? How is this
+idea best presented? As a continuation of existing Ember patterns, or as a
+wholly new one?
+
+> Would the acceptance of this proposal mean the Ember guides must be
+re-organized or altered? Does it change how Ember is taught to new users
+at any level?
+
+> How should this feature be introduced and taught to existing Ember
+users?
+
+## Drawbacks
+
+> Why should we *not* do this? Please consider the impact on teaching Ember,
+on the integration of this feature with other existing and planned features,
+on the impact of the API churn on existing apps, etc.
+
+> There are tradeoffs to choosing any path, please attempt to identify them here.
+
+## Alternatives
+
+> What other designs have been considered? What is the impact of not doing this?
+
+> This section could also include prior art, that is, how other frameworks in the same domain have solved this problem.
+
+## Unresolved questions
+
+> Optional, but suggested for first drafts. What parts of the design are still
+TBD?

--- a/text/0000-controller-migration-path.md
+++ b/text/0000-controller-migration-path.md
@@ -402,8 +402,3 @@ In the release that makes these capabilities a default, any pages mentioning the
 ## Drawbacks
 
 - Routes may feel like they are configuration (this may be fine)
-
-## Unresolved questions
-
- - Should this RFC include the idea that's been floating around recently where `Route` defines an `arguments` getter where those arguments are splatted onto the `render` component, rather than receiving a single `@model` argument. This would mean that the `Route` would need to have a way to manage the resolved model so that `arguments` doesn't need to worry about pending promises.
- - For error templates today, is `this.model` the error?

--- a/text/0000-controller-migration-path.md
+++ b/text/0000-controller-migration-path.md
@@ -239,6 +239,8 @@ Given a visit to `/posts`
   - this component is invoked _as if_ `template:posts` was defined as `<Posts @model={{this.model}} />`
 - default to `{{outlet}}` or `{{yield}}` for sub routes
 
+**NOTE** as a side effect of treating the default template in this manner, it would become a requirement, in order to maintain cohesion, that we treat loading and error templates similar to the above lookup rules.
+
 ## How we teach this
 
 Since this is a new programming paradigm, we'll want to update the guides and tutorials to reflect a new "happy path".

--- a/text/0000-controller-migration-path.md
+++ b/text/0000-controller-migration-path.md
@@ -224,6 +224,19 @@ These are not "routable components", but components that are invoked after the `
     {{/each}}
     ```
 
+### Lookup Priority Rules
+
+For each of these, assume that all parent routes/templates/etc have resolved.
+Because there are 4 or 5 project structure layouts in flux, the notation here is what is used inside the resolver.
+
+Given a visit to `/posts`
+1. lookup `template:posts`  
+  a. if a controller exists, the template will be rendered as it is today.  
+  b. if a controller does not exist, a template-only component will be assumed, passing the `@model` argument. This will make interop between controllers' templates and template-only component / used-for-route template components inconsistent, so controllers' templates should also get a `@model` argument.
+2. lookup a component named "posts", `component:posts` and `template:components/posts`.   
+  NOTE: if the `template:posts` template was found, this step does not happen.  
+  a. this component is invoked _as if_ `template:posts` was defined as `<Posts @model={{this.model}} />`
+
 ## Drawbacks
 
 It's very important that every use case for controllers today _can_ be implemented using the aforementioned techniques. If people are willing to share their controller scenarios, we can provide a library of examples of translation so that others may migrate more quickly.

--- a/text/0000-controller-migration-path.md
+++ b/text/0000-controller-migration-path.md
@@ -230,13 +230,13 @@ For each of these, assume that all parent routes/templates/etc have resolved.
 Because there are 4 or 5 project structure layouts in flux, the notation here is what is used inside the resolver.
 
 Given a visit to `/posts`
-1. lookup `template:posts`  
-  a. if a controller exists, the template will be rendered as it is today.  
-  b. if a controller does not exist, a template-only component will be assumed, passing the `@model` argument. This will make interop between controllers' templates and template-only component / used-for-route template components inconsistent, so controllers' templates should also get a `@model` argument.
-2. lookup a component named "posts", `component:posts` and `template:components/posts`.   
+- lookup `template:posts`  
+  - if a controller exists, the template will be rendered as it is today.  
+  - if a controller does not exist, a template-only component will be assumed, passing the `@model` argument. This will make interop between controllers' templates and template-only component / used-for-route template components inconsistent, so controllers' templates should also get a `@model` argument.
+- lookup a component named "posts", `component:posts` and `template:components/posts`.   
   NOTE: if the `template:posts` template was found, this step does not happen.  
-  a. this component is invoked _as if_ `template:posts` was defined as `<Posts @model={{this.model}} />`
-3. default to `{{outlet}}` or `{{yield}}` for sub routes
+  - this component is invoked _as if_ `template:posts` was defined as `<Posts @model={{this.model}} />`
+- default to `{{outlet}}` or `{{yield}}` for sub routes
 
 ## Drawbacks
 


### PR DESCRIPTION
[rendered](https://github.com/NullVoxPopuli/rfcs/blob/controller-migration-path/text/0000-controller-migration-path.md)

depends on: 
   - ~[RFC 496: Handlebars Strict Mode](https://github.com/emberjs/rfcs/pull/496)~
   - [RFC 454: SFC & Template Import Primitives](https://github.com/emberjs/rfcs/pull/454)
   - ~~[RFC 380: Add queryParams to the router service](https://github.com/emberjs/rfcs/pull/380)~~
     - or: [RFC 712: Query Params as Derived Data](https://github.com/emberjs/rfcs/pull/712) 
             and [RFC 715: Arbitrary Query Params](https://github.com/emberjs/rfcs/pull/715) 

Update (2020-02-08):
 - I need to rewrite some stuff to account for:
   - RFCs #454 and #496 aren't actually a requirement, but more just fit along with my ideal framework semantics
   - ~~[RFC 570: URL Manager](https://github.com/emberjs/rfcs/pull/570) replaced #380 (and is required, because without controllers, we need a way to handle query params)~~
   
 Update (2020-03-03):
 - I need to rewrite some stuff to account for:
    - new derived data approach to query params and arbitrary query params
    - Need to discuss ideas presented in Ember Discord after strict-mode / template imports started being experimenting with and folks were trying to figure out how to make route templates less awkward: https://discord.com/channels/480462759797063690/518154533143183377/815728311841062944