### PR TITLE
deprecate tryinvoke

### DIFF
--- a/text/0000-deprecate-tryinvoke.md
+++ b/text/0000-deprecate-tryinvoke.md
@@ -1,0 +1,91 @@
+- Start Date: 2020-10-02
+- Relevant Team(s): Ember.js
+- RFC PR: (after opening the RFC PR, update this with a link to it and update the file name)
+- Tracking: (leave this empty)
+
+# <RFC title>
+
+## Summary
+
+Deprecate support for `tryInvoke` in Ember's Utils module (@ember/utils) because the Javascript language has [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) for us to use as a native solution.
+
+## Motivation
+
+In most cases, function arguments should not be optional, but in the rare occasion that it is optional, the Javascript language has [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) so we can deprecate the usage of `tryInvoke`.
+
+## Transition Path
+
+Ember will start logging deprecation messages for `tryInvoke` usage. 
+
+We can codemod our current usage of `tryInvoke` with the equivalent behaviour using plain JavaScript. The migration guide will cover this example:
+
+Before:
+
+```js
+import { tryInvoke } from '@ember/utils';
+ 
+foo() {
+ tryInvoke(this.args, 'bar', ['baz']);
+}
+```
+
+After:
+
+```js
+foo() {
+ this.args.bar?.('baz');
+}
+```
+
+#### Using Optional Chaining Operator
+
+The optional chaining operator `?.` permits reading the value of a property located deep within a chain of connected objects without having to expressly validate that each reference in the chain is valid. The `?.` operator functions similarly to the `.` chaining operator, except that instead of causing an error if a reference is nullish (`null` or `undefined`), the expression short-circuits with a return value of `undefined`. When used with function calls, it returns `undefined` if the given function does not exist:
+
+```js
+const adventurer = {
+  name: 'Alice',
+  cat: {
+    name: 'Dinah'
+  }
+};
+
+const dogName = adventurer.dog?.name;
+console.log(dogName);
+// expected output: undefined
+
+console.log(adventurer.someNonExistentMethod?.());
+// expected output: undefined
+```
+
+Tooling Support:
+
+- [Babel](https://babeljs.io/) already supports the [optional chaining operator](https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining) so we can use that for future use-cases.
+
+- [TypeScript](https://github.com/microsoft/TypeScript), similarly, as of [version 3.7](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#optional-chaining) also supports the operator so we will not be breaking that flow either.
+
+## How We Teach This
+
+Add the transition path to the [Ember Deprecation Guide](https://deprecations.emberjs.com/).
+
+The references to `tryInvoke` will need to be removed from the [API docs](https://api.emberjs.com/ember/release/functions/@ember%2Futils/tryInvoke). 
+
+There are no changes needed for the [Ember Guides](https://guides.emberjs.com/release/) since we do not use it anywhere.
+
+## Drawbacks
+
+This change will cause some deprecation noise but could be mitigated with a codemod.
+
+## Alternatives
+
+We could check that the function name exists on the object before invocation using an `if` block, but this alternative leaves the developer to have to wrap each function call in an `if` block, making this pattern very cumbersome.
+
+```js
+foo() {
+  if (typeof this.args.bar === 'function') {
+    this.args.bar('baz');
+  }
+}
+```
+## Unresolved questions
+
+None at the moment.

--- a/text/0000-deprecate-tryinvoke.md
+++ b/text/0000-deprecate-tryinvoke.md
@@ -1,6 +1,6 @@
 - Start Date: 2020-10-02
 - Relevant Team(s): Ember.js
-- RFC PR: (after opening the RFC PR, update this with a link to it and update the file name)
+- RFC PR: https://github.com/emberjs/rfcs/pull/673/files
 - Tracking: (leave this empty)
 
 # <RFC title>

--- a/text/0673-deprecate-tryinvoke.md
+++ b/text/0673-deprecate-tryinvoke.md
@@ -137,7 +137,7 @@ In the rare occasion that a Function argument is optional by design, you can use
 
 ```js
 // app/components/child.js
-foo() {
+fooChild() {
  this.args.bar?.('baz');
 }
 ```

--- a/text/0673-deprecate-tryinvoke.md
+++ b/text/0673-deprecate-tryinvoke.md
@@ -7,15 +7,15 @@
 
 ## Summary
 
-Deprecate support for `tryInvoke` in Ember's Utils module (@ember/utils) because the Javascript language has [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) for us to use as a native solution.
+Deprecate support for `tryInvoke` in Ember's Utils module (@ember/utils) because the JavaScript language has [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) for us to use as a native solution.
 
 ## Motivation
 
-In most cases, function arguments should not be optional, but in the rare occasion that it is optional, the Javascript language has [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) so we can deprecate the usage of `tryInvoke`.
+In most cases, Function arguments should not be optional, but in the rare occasion that it is optional, the JavaScript language has [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) so we can deprecate the usage of `tryInvoke`.
 
 ## Transition Path
 
-Ember will start logging deprecation messages for `tryInvoke` usage. Deprecation text: `Using tryInvoke has been deprecated. Instead, consider using native Javascript optional chaining.`
+Ember will start logging deprecation messages for `tryInvoke` usage. Deprecation text: `Using tryInvoke has been deprecated. Instead, consider using native JavaScript optional chaining.`
 
 We can codemod our current usage of `tryInvoke` with the equivalent behaviour using plain JavaScript. The migration guide will cover this example:
 
@@ -23,7 +23,7 @@ Before:
 
 ```js
 import { tryInvoke } from '@ember/utils';
- 
+
 foo() {
  tryInvoke(this.args, 'bar', ['baz']);
 }
@@ -39,7 +39,7 @@ foo() {
 
 #### Using Optional Chaining Operator
 
-The optional chaining operator `?.` permits reading the value of a property located deep within a chain of connected objects without having to expressly validate that each reference in the chain is valid. The `?.` operator functions similarly to the `.` chaining operator, except that instead of causing an error if a reference is nullish (`null` or `undefined`), the expression short-circuits with a return value of `undefined`. When used with function calls, it returns `undefined` if the given function does not exist:
+The optional chaining operator `?.` permits reading the value of a property located deep within a chain of connected objects without having to expressly validate that each reference in the chain is valid. The `?.` operator functions similarly to the `.` chaining operator, except that instead of causing an error if a reference is nullish (`null` or `undefined`), the expression short-circuits with a return value of `undefined`. When used with Function calls, it returns `undefined` if the given function does not exist:
 
 ```js
 const adventurer = {
@@ -67,11 +67,80 @@ Tooling Support:
 
 ## How We Teach This
 
-Add the transition path to the [Ember Deprecation Guide](https://deprecations.emberjs.com/). Deprecation text: `Using tryInvoke has been deprecated. Instead, consider using native Javascript optional chaining.`
+#### Add to Ember Deprecation Guide
 
-The references to `tryInvoke` will need to be removed from the [API docs](https://api.emberjs.com/ember/release/functions/@ember%2Futils/tryInvoke). 
+In the [Ember Deprecation Guide](https://deprecations.emberjs.com/) we should add the following text:
 
-There are no changes needed for the [Ember Guides](https://guides.emberjs.com/release/) since we do not use it anywhere.
+Deprecate support for `tryInvoke` in Ember's Utils module (@ember/utils). In most cases, Function arguments should not be optional, but in the rare occasion that it is optional, we can use native JavaScript's [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) as a solution.
+
+Before:
+
+```js
+import { tryInvoke } from '@ember/utils';
+
+foo() {
+ tryInvoke(this.args, 'bar', ['baz']);
+}
+```
+
+After:
+
+```js
+foo() {
+ this.args.bar?.('baz');
+}
+```
+
+#### Remove from API docs
+
+The references to `tryInvoke` will need to be removed from the [API docs](https://api.emberjs.com/ember/release/functions/@ember%2Futils/tryInvoke).
+
+#### Add to Ember Guides
+
+In [Ember Guides](https://guides.emberjs.com/release/) under [Arguments](https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/) we should create 2 new sub-headings:
+
+`Function Arguments`:
+Arguments passed into components can be of type [Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Functions). In most cases, Function arguments should be treated as required arguments and therefore should be invoked with normal Function invocation `()`.
+
+```js
+// app/components/parent.js
+@action
+fooParent() {
+ // ...
+}
+```
+
+```hbs
+{{!-- app/components/parent.hbs --}}
+<Child @bar={{this.fooParent}} />
+```
+
+```js
+// app/components/child.js
+fooChild() {
+ this.args.bar('baz');
+}
+```
+
+`Optional Function Arguments`:
+In the rare occasion that a Function argument is optional by design, you can use native JavaScript's [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) to invoke the optional Function argument `?.()`.
+
+```hbs
+{{!-- app/components/parent.hbs --}}
+<Child @bar={{this.fooParent}} />
+```
+
+```hbs
+{{!-- app/components/some-other-parent.hbs --}}
+<Child />
+```
+
+```js
+// app/components/child.js
+foo() {
+ this.args.bar?.('baz');
+}
+```
 
 ## Drawbacks
 
@@ -79,7 +148,7 @@ This change will cause some deprecation noise but could be mitigated with a code
 
 ## Alternative Solutions
 
-We could check that the function name exists on the object before invocation using an `if` block, but this alternative leaves the developer to have to wrap each function call in an `if` block, making this pattern very cumbersome.
+We could check that the Function name exists on the object before invocation using an `if` block, but this alternative leaves the developer to have to wrap each Function call in an `if` block, making this pattern very cumbersome.
 
 ```js
 foo() {

--- a/text/0673-deprecate-tryinvoke.md
+++ b/text/0673-deprecate-tryinvoke.md
@@ -3,7 +3,7 @@
 - RFC PR: https://github.com/emberjs/rfcs/pull/673
 - Tracking: (leave this empty)
 
-# <RFC title>
+# Deprecate `tryInvoke`
 
 ## Summary
 
@@ -61,11 +61,13 @@ Tooling Support:
 
 - [Babel](https://babeljs.io/) already supports the [optional chaining operator](https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining) so we can use that for future use-cases.
 
+- [ember-cli-babel](https://www.npmjs.com/package/ember-cli-babel) all recent versions support optional chaining operator.
+
 - [TypeScript](https://github.com/microsoft/TypeScript), similarly, as of [version 3.7](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#optional-chaining) also supports the operator so we will not be breaking that flow either.
 
 ## How We Teach This
 
-Add the transition path to the [Ember Deprecation Guide](https://deprecations.emberjs.com/).
+Add the transition path to the [Ember Deprecation Guide](https://deprecations.emberjs.com/). Deprecation text: `Using tryInvoke has been deprecated. Instead, consider using native Javascript optional chaining.`
 
 The references to `tryInvoke` will need to be removed from the [API docs](https://api.emberjs.com/ember/release/functions/@ember%2Futils/tryInvoke). 
 

--- a/text/0673-deprecate-tryinvoke.md
+++ b/text/0673-deprecate-tryinvoke.md
@@ -100,7 +100,7 @@ The references to `tryInvoke` will need to be removed from the [API docs](https:
 In [Ember Guides](https://guides.emberjs.com/release/) under the [Arguments](https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/) section, we will create 2 new sub-headings called `Function Arguments` and `Optional Function Arguments`:
 
 #### Function Arguments
-Arguments passed into components can be of type [Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Functions). In most cases, Function arguments should be treated as required arguments and therefore should be invoked with normal Function invocation `()`.
+Arguments passed into components can be of type [Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Functions). In most cases, Function arguments should be treated as required arguments and therefore should be invoked with normal Function invocation `()`. It is important to intentionally treat Function arguments as required because in the off chance that the Function argument is not passed into the child component correctly, normal Function invocation `()` will cause a runtime exception and produce a stack trace, making it easier for the developer to find the root cause of the bug.
 
 ```js
 // app/components/parent.js
@@ -123,7 +123,7 @@ fooChild() {
 ```
 
 #### Optional Function Arguments
-In the rare occasion that a Function argument is optional by design, you can use native JavaScript's [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) to invoke the optional Function argument `?.()`.
+In the rare occasion that a Function argument is optional by design, you can use native JavaScript's [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) to invoke the optional Function argument `?.()`. We want to avoid unintentionally treating Function arguments as optional because optional chaining invocation has the side effect of failing silently with no stack trace produced. This will cause a difficult debugging experience for the developer.
 
 ```hbs
 {{!-- app/components/parent.hbs --}}

--- a/text/0673-deprecate-tryinvoke.md
+++ b/text/0673-deprecate-tryinvoke.md
@@ -1,6 +1,6 @@
 - Start Date: 2020-10-02
 - Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/673/files
+- RFC PR: https://github.com/emberjs/rfcs/pull/673
 - Tracking: (leave this empty)
 
 # <RFC title>

--- a/text/0673-deprecate-tryinvoke.md
+++ b/text/0673-deprecate-tryinvoke.md
@@ -77,7 +77,7 @@ There are no changes needed for the [Ember Guides](https://guides.emberjs.com/re
 
 This change will cause some deprecation noise but could be mitigated with a codemod.
 
-## Alternatives
+## Alternative Solutions
 
 We could check that the function name exists on the object before invocation using an `if` block, but this alternative leaves the developer to have to wrap each function call in an `if` block, making this pattern very cumbersome.
 
@@ -88,6 +88,12 @@ foo() {
   }
 }
 ```
+
+## Alternatives
+
+#### Do nothing
+We could keep support in place, and provide more guidance around using it.
+
 ## Unresolved questions
 
 None at the moment.

--- a/text/0673-deprecate-tryinvoke.md
+++ b/text/0673-deprecate-tryinvoke.md
@@ -99,7 +99,7 @@ The references to `tryInvoke` will need to be removed from the [API docs](https:
 
 In [Ember Guides](https://guides.emberjs.com/release/) under [Arguments](https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/) we should create 2 new sub-headings:
 
-`Function Arguments`:
+#### Function Arguments
 Arguments passed into components can be of type [Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Functions). In most cases, Function arguments should be treated as required arguments and therefore should be invoked with normal Function invocation `()`.
 
 ```js
@@ -122,7 +122,7 @@ fooChild() {
 }
 ```
 
-`Optional Function Arguments`:
+#### Optional Function Arguments
 In the rare occasion that a Function argument is optional by design, you can use native JavaScript's [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) to invoke the optional Function argument `?.()`.
 
 ```hbs

--- a/text/0673-deprecate-tryinvoke.md
+++ b/text/0673-deprecate-tryinvoke.md
@@ -67,7 +67,7 @@ Tooling Support:
 
 ## How We Teach This
 
-#### Add to Ember Deprecation Guide
+### Add to Ember Deprecation Guide
 
 In the [Ember Deprecation Guide](https://deprecations.emberjs.com/) we should add the following text:
 
@@ -91,11 +91,11 @@ foo() {
 }
 ```
 
-#### Remove from API docs
+### Remove from API docs
 
 The references to `tryInvoke` will need to be removed from the [API docs](https://api.emberjs.com/ember/release/functions/@ember%2Futils/tryInvoke).
 
-#### Add to Ember Guides
+### Add to Ember Guides
 
 In [Ember Guides](https://guides.emberjs.com/release/) under [Arguments](https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/) we should create 2 new sub-headings:
 

--- a/text/0673-deprecate-tryinvoke.md
+++ b/text/0673-deprecate-tryinvoke.md
@@ -7,11 +7,11 @@
 
 ## Summary
 
-Deprecate support for `tryInvoke` in Ember's Utils module (@ember/utils) because the JavaScript language has [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) for us to use as a native solution.
+Deprecate support for `tryInvoke` in Ember's Utils module (@ember/utils) because native JavaScript has [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) for developers to use as an alternative solution. Deprecating `tryInvoke` will help to reduce Ember API redundancy.
 
 ## Motivation
 
-In most cases, Function arguments should not be optional, but in the rare occasion that it is optional, the JavaScript language has [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) so we can deprecate the usage of `tryInvoke`.
+In most cases, Function arguments should not be optional, but in the rare occasion that a Function argument is intentionally optional by design, we can use native JavaScript's [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) as a solution. Deprecating `tryInvoke` will help to reduce Ember API redundancy.
 
 ## Transition Path
 
@@ -71,7 +71,7 @@ Tooling Support:
 
 In the [Ember Deprecation Guide](https://deprecations.emberjs.com/) we will add the following text:
 
-Deprecate support for `tryInvoke` in Ember's Utils module (@ember/utils). In most cases, Function arguments should not be optional, but in the rare occasion that it is optional, we can use native JavaScript's [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) as a solution. Deprecating `tryInvoke` will help to reduce Ember API redundancy.
+Deprecate support for `tryInvoke` in Ember's Utils module (@ember/utils). In most cases, Function arguments should not be optional, but in the rare occasion that a Function argument is intentionally optional by design, we can use native JavaScript's [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) as a solution. Deprecating `tryInvoke` will help to reduce Ember API redundancy.
 
 Before:
 
@@ -123,7 +123,7 @@ fooChild() {
 ```
 
 #### Optional Function Arguments
-In the rare occasion that a Function argument is optional by design, you can use native JavaScript's [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) to invoke the optional Function argument `?.()`. We want to avoid unintentionally treating Function arguments as optional because optional chaining invocation has the side effect of failing silently with no stack trace logged. This will cause a difficult debugging experience for the developer.
+In the rare occasion that a Function argument is intentionally optional by design, you can use native JavaScript's [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) to invoke the optional Function argument `?.()`. We want to avoid unintentionally treating Function arguments as optional because optional chaining invocation has the side effect of failing silently with no stack trace logged. This will cause a difficult debugging experience for the developer.
 
 ```hbs
 {{!-- app/components/parent.hbs --}}

--- a/text/0673-deprecate-tryinvoke.md
+++ b/text/0673-deprecate-tryinvoke.md
@@ -100,7 +100,7 @@ The references to `tryInvoke` will need to be removed from the [API docs](https:
 In [Ember Guides](https://guides.emberjs.com/release/) under the [Arguments](https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/) section, we will create 2 new sub-headings called `Function Arguments` and `Optional Function Arguments`:
 
 #### Function Arguments
-Arguments passed into components can be of type [Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Functions). In most cases, Function arguments should be treated as required arguments and therefore should be invoked with normal Function invocation `()`. It is important to intentionally treat Function arguments as required because in the off chance that the Function argument is not passed into the child component correctly, normal Function invocation `()` will cause a runtime exception and produce a stack trace, making it easier for the developer to find the root cause of the bug.
+Arguments passed into components can be of type [Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Functions). In most cases, Function arguments should be treated as required arguments and therefore should be invoked with normal Function invocation `()`. It is important to intentionally treat Function arguments as required because in the off chance that the Function argument is `undefined`, normal Function invocation `()` will cause a runtime exception and produce a stack trace, making it easier for the developer to find the root cause of the bug.
 
 ```js
 // app/components/parent.js
@@ -123,7 +123,7 @@ fooChild() {
 ```
 
 #### Optional Function Arguments
-In the rare occasion that a Function argument is optional by design, you can use native JavaScript's [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) to invoke the optional Function argument `?.()`. We want to avoid unintentionally treating Function arguments as optional because optional chaining invocation has the side effect of failing silently with no stack trace produced. This will cause a difficult debugging experience for the developer.
+In the rare occasion that a Function argument is optional by design, you can use native JavaScript's [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) to invoke the optional Function argument `?.()`. We want to avoid unintentionally treating Function arguments as optional because optional chaining invocation has the side effect of failing silently with no stack trace logged. This will cause a difficult debugging experience for the developer.
 
 ```hbs
 {{!-- app/components/parent.hbs --}}

--- a/text/0673-deprecate-tryinvoke.md
+++ b/text/0673-deprecate-tryinvoke.md
@@ -15,7 +15,7 @@ In most cases, function arguments should not be optional, but in the rare occasi
 
 ## Transition Path
 
-Ember will start logging deprecation messages for `tryInvoke` usage. 
+Ember will start logging deprecation messages for `tryInvoke` usage. Deprecation text: `Using tryInvoke has been deprecated. Instead, consider using native Javascript optional chaining.`
 
 We can codemod our current usage of `tryInvoke` with the equivalent behaviour using plain JavaScript. The migration guide will cover this example:
 

--- a/text/0673-deprecate-tryinvoke.md
+++ b/text/0673-deprecate-tryinvoke.md
@@ -69,7 +69,7 @@ Tooling Support:
 
 ### Add to Ember Deprecation Guide
 
-In the [Ember Deprecation Guide](https://deprecations.emberjs.com/) we should add the following text:
+In the [Ember Deprecation Guide](https://deprecations.emberjs.com/) we will add the following text:
 
 Deprecate support for `tryInvoke` in Ember's Utils module (@ember/utils). In most cases, Function arguments should not be optional, but in the rare occasion that it is optional, we can use native JavaScript's [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) as a solution.
 
@@ -97,7 +97,7 @@ The references to `tryInvoke` will need to be removed from the [API docs](https:
 
 ### Add to Ember Guides
 
-In [Ember Guides](https://guides.emberjs.com/release/) under [Arguments](https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/) we should create 2 new sub-headings:
+In [Ember Guides](https://guides.emberjs.com/release/) under [Arguments](https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/) we will create 2 new sub-headings called `Function Arguments` and `Optional Function Arguments`:
 
 #### Function Arguments
 Arguments passed into components can be of type [Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Functions). In most cases, Function arguments should be treated as required arguments and therefore should be invoked with normal Function invocation `()`.

--- a/text/0673-deprecate-tryinvoke.md
+++ b/text/0673-deprecate-tryinvoke.md
@@ -71,7 +71,7 @@ Tooling Support:
 
 In the [Ember Deprecation Guide](https://deprecations.emberjs.com/) we will add the following text:
 
-Deprecate support for `tryInvoke` in Ember's Utils module (@ember/utils). In most cases, Function arguments should not be optional, but in the rare occasion that it is optional, we can use native JavaScript's [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) as a solution.
+Deprecate support for `tryInvoke` in Ember's Utils module (@ember/utils). In most cases, Function arguments should not be optional, but in the rare occasion that it is optional, we can use native JavaScript's [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) as a solution. Deprecating `tryInvoke` will help to reduce Ember API redundancy.
 
 Before:
 
@@ -97,7 +97,7 @@ The references to `tryInvoke` will need to be removed from the [API docs](https:
 
 ### Add to Ember Guides
 
-In [Ember Guides](https://guides.emberjs.com/release/) under [Arguments](https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/) we will create 2 new sub-headings called `Function Arguments` and `Optional Function Arguments`:
+In [Ember Guides](https://guides.emberjs.com/release/) under the [Arguments](https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/) section, we will create 2 new sub-headings called `Function Arguments` and `Optional Function Arguments`:
 
 #### Function Arguments
 Arguments passed into components can be of type [Function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Functions). In most cases, Function arguments should be treated as required arguments and therefore should be invoked with normal Function invocation `()`.


### PR DESCRIPTION
Building on [RFC #0554: Deprecate getWithDefault](https://emberjs.github.io/rfcs/0554-deprecate-getwithdefault.html), deprecate `tryInvoke` as well.

[Rendered](https://github.com/bachvo/rfcs/blob/deprecate-tryinvoke/text/0673-deprecate-tryinvoke.md)