### PR TITLE
Add Github Workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Checkout tools repo
+        uses: actions/checkout@v2
+        with:
+          repository: kategengler/rfcs-tooling
+          path: rfcs-tooling
+
+      - uses: actions/setup-node@v2.1.2
+
+      - run: yarn install
+        working-directory: rfcs-tooling
+
+      - run: node lint-rfc-frontmatter.js ../text/*.md
+        working-directory: rfcs-tooling

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout tools repo
         uses: actions/checkout@v2
         with:
-          repository: kategengler/rfcs-tooling
+          repository: emberjs/rfcs-tooling
           path: rfcs-tooling
 
       - uses: actions/setup-node@v2.1.2

--- a/.github/workflows/ensure-filename.yml
+++ b/.github/workflows/ensure-filename.yml
@@ -1,16 +1,17 @@
-name: CI
+name: Ensure Filename of RFCs
 
 on:
-  push:
-    branches: [ master ]
-  pull_request: {}
+  pull_request:
+    paths:
+      - 'text/*.md'
 
 jobs:
-  lint-frontmatter:
+  check-filename:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
+      - id: files
+        uses: jitterbit/get-changed-files@v1
       - name: Checkout tools repo
         uses: actions/checkout@v2
         with:
@@ -22,6 +23,8 @@ jobs:
       - run: yarn install
         working-directory: rfcs-tooling
 
-      - name: Lint the frontmatter of all RFCs for informational purposes
-        run: node lint-rfc-frontmatter.js ../text/*.md || true # Don't want to fail on old RFCs just yet
+      - name: Test RFC Filename matches PR Number that adds it
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: node check-filename-matches-pr.js $PR_NUMBER ${{ steps.files.outputs.added }}
         working-directory: rfcs-tooling

--- a/.github/workflows/ensure-filename.yml
+++ b/.github/workflows/ensure-filename.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout tools repo
         uses: actions/checkout@v2
         with:
-          repository: kategengler/rfcs-tooling
+          repository: emberjs/rfcs-tooling
           path: rfcs-tooling
 
       - uses: actions/setup-node@v2.1.2


### PR DESCRIPTION
- One checks that any added RFC has a filename reflecting the PR #. 

- The other runs a linter for the future frontmatter format for RFCs. We have not yet switched to this frontmatter, so it runs without failing for now (but lets us see the output and sets up a spot for other CI). 

It uses a second repo to store the tooling that will be used in these workflows, so as not to overwhelm the activity in this repo, which should primarily be for RFCs. 

It's currently under my own name, but looking to move it into emberjs as soon as I get a second 👍.  