### PR TITLE
Convert RFC metadata to real frontmatter

### DIFF
--- a/text/0001-transform-attribute-meta-parameter.md
+++ b/text/0001-transform-attribute-meta-parameter.md
@@ -1,6 +1,9 @@
-- Start Date: 2014-08-14
-- RFC PR: https://github.com/emberjs/rfcs/pull/1
-- Ember Issue: https://github.com/emberjs/data/pull/4086
+---
+Start Date: 2014-08-14
+RFC PR: https://github.com/emberjs/rfcs/pull/1
+Ember Issue: https://github.com/emberjs/data/pull/4086
+
+---
 
 # Summary
 

--- a/text/0003-block-params.md
+++ b/text/0003-block-params.md
@@ -1,9 +1,12 @@
-- Start Date: 2014-08-18
-- RFC PR: https://github.com/emberjs/rfcs/pull/3
-- Issues:
-  - Ember Stream support: emberjs/ember.js#5522
-  - Handlebars parser support: wycats/handlebars.js#906
-  - HTMLBars compiler support: tildeio/htmlbars#147
+---
+Start Date: 2014-08-18
+RFC PR: https://github.com/emberjs/rfcs/pull/3
+Issues:
+  Ember Stream support: emberjs/ember.js#5522
+  Handlebars parser support: wycats/handlebars.js#906
+  HTMLBars compiler support: tildeio/htmlbars#147
+
+---
 
 # Summary
 

--- a/text/0003-cli-ember-doctor.md
+++ b/text/0003-cli-ember-doctor.md
@@ -1,6 +1,9 @@
-- Start Date: 2015-01-10
-- Relevant Team(s): Ember CLI
-- RFC PR: [#3](https://github.com/ember-cli/rfcs/pull/3)
+---
+Start Date: 2015-01-10
+Relevant Team(s): Ember CLI
+RFC PR: #3
+
+---
 
 # Summary
 

--- a/text/0003-cli-ember-doctor.md
+++ b/text/0003-cli-ember-doctor.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2015-01-10
 Relevant Team(s): Ember CLI
-RFC PR: #3
+RFC PR: https://github.com/ember-cli/rfcs/pull/3
 
 ---
 

--- a/text/0010-engines.md
+++ b/text/0010-engines.md
@@ -1,6 +1,9 @@
-- Start Date: 2014-10-24
-- RFC PR: https://github.com/emberjs/rfcs/pull/10
-- Ember Issue: https://github.com/emberjs/ember.js/pull/12685
+---
+Start Date: 2014-10-24
+RFC PR: https://github.com/emberjs/rfcs/pull/10
+Ember Issue: https://github.com/emberjs/ember.js/pull/12685
+
+---
 
 # Summary
 

--- a/text/0011-improved-cp-syntax.md
+++ b/text/0011-improved-cp-syntax.md
@@ -1,6 +1,9 @@
-- Start Date: 2014-09-30
-- RFC PR: https://github.com/emberjs/rfcs/pull/11
-- Ember Issue: https://github.com/emberjs/ember.js/pull/9527
+---
+Start Date: 2014-09-30
+RFC PR: https://github.com/emberjs/rfcs/pull/11
+Ember Issue: https://github.com/emberjs/ember.js/pull/9527
+
+---
 
 # Summary
 

--- a/text/0012-help-json-output.md
+++ b/text/0012-help-json-output.md
@@ -1,6 +1,9 @@
-- Start Date: 2015-05-16
-- Relevant Team(s): Ember CLI
-- RFC PR: [#12](https://github.com/ember-cli/rfcs/pull/12)
+---
+Start Date: 2015-05-16
+Relevant Team(s): Ember CLI
+RFC PR: #12
+
+---
 
 # Summary
 

--- a/text/0012-help-json-output.md
+++ b/text/0012-help-json-output.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2015-05-16
 Relevant Team(s): Ember CLI
-RFC PR: #12
+RFC PR: https://github.com/ember-cli/rfcs/pull/12
 
 ---
 

--- a/text/0015-the-road-to-ember-2-0.md
+++ b/text/0015-the-road-to-ember-2-0.md
@@ -1,6 +1,9 @@
-- Start Date: 2014-12-03
-- RFC PR: https://github.com/emberjs/rfcs/pull/15
-- Ember Issue: This RFC is implemented over many Ember PRs
+---
+Start Date: 2014-12-03
+RFC PR: https://github.com/emberjs/rfcs/pull/15
+Ember Issue: This RFC is implemented over many Ember PRs
+
+---
 
 # The Road to Ember 2.0
 

--- a/text/0020-sri-default.md
+++ b/text/0020-sri-default.md
@@ -1,6 +1,9 @@
-- Start Date: 2015-07-10
-- Relevant Team(s): Ember CLI
-- RFC PR: [#20](https://github.com/ember-cli/rfcs/pull/20)
+---
+Start Date: 2015-07-10
+Relevant Team(s): Ember CLI
+RFC PR: #20
+
+---
 
 # Summary
 

--- a/text/0020-sri-default.md
+++ b/text/0020-sri-default.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2015-07-10
 Relevant Team(s): Ember CLI
-RFC PR: #20
+RFC PR: https://github.com/ember-cli/rfcs/pull/20
 
 ---
 

--- a/text/0023-command-line-completion.md
+++ b/text/0023-command-line-completion.md
@@ -1,6 +1,9 @@
-- Start Date: 2015-08-18
-- Relevant Team(s): Ember CLI
-- RFC PR: [#23](https://github.com/ember-cli/rfcs/pull/23)
+---
+Start Date: 2015-08-18
+Relevant Team(s): Ember CLI
+RFC PR: #23
+
+---
 
 # Summary
 

--- a/text/0023-command-line-completion.md
+++ b/text/0023-command-line-completion.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2015-08-18
 Relevant Team(s): Ember CLI
-RFC PR: #23
+RFC PR: https://github.com/ember-cli/rfcs/pull/23
 
 ---
 

--- a/text/0024-bound-attributes.md
+++ b/text/0024-bound-attributes.md
@@ -1,6 +1,9 @@
-- 2014-11-26
-- RFC PR: https://github.com/emberjs/rfcs/pull/24
-- Ember Issue:
+---
+2014-11-26: 
+RFC PR: https://github.com/emberjs/rfcs/pull/24
+Ember Issue: 
+
+---
 
 # Summary
 

--- a/text/0024-bound-attributes.md
+++ b/text/0024-bound-attributes.md
@@ -1,7 +1,6 @@
 ---
-2014-11-26: 
+Start Date: 2014-11-26 
 RFC PR: https://github.com/emberjs/rfcs/pull/24
-Ember Issue: 
 
 ---
 

--- a/text/0028-app-import-output-file.md
+++ b/text/0028-app-import-output-file.md
@@ -1,6 +1,9 @@
-- Start Date: 2015-11-02
-- Relevant Team(s): Ember CLI
-- RFC PR: [#28](https://github.com/ember-cli/rfcs/pull/28)
+---
+Start Date: 2015-11-02
+Relevant Team(s): Ember CLI
+RFC PR: #28
+
+---
 
 # Summary
 

--- a/text/0028-app-import-output-file.md
+++ b/text/0028-app-import-output-file.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2015-11-02
 Relevant Team(s): Ember CLI
-RFC PR: #28
+RFC PR: https://github.com/ember-cli/rfcs/pull/28
 
 ---
 

--- a/text/0029-addon-black-and-whitelist-for-apps.md
+++ b/text/0029-addon-black-and-whitelist-for-apps.md
@@ -1,6 +1,9 @@
-- Start Date: 2015-11-11
-- Relevant Team(s): Ember CLI
-- RFC PR: [#29](https://github.com/ember-cli/rfcs/pull/29)
+---
+Start Date: 2015-11-11
+Relevant Team(s): Ember CLI
+RFC PR: #29
+
+---
 
 # Summary
 

--- a/text/0029-addon-black-and-whitelist-for-apps.md
+++ b/text/0029-addon-black-and-whitelist-for-apps.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2015-11-11
 Relevant Team(s): Ember CLI
-RFC PR: #29
+RFC PR: https://github.com/ember-cli/rfcs/pull/29
 
 ---
 

--- a/text/0045-internet-explorer.md
+++ b/text/0045-internet-explorer.md
@@ -1,6 +1,9 @@
-- Start Date: 2015-06-07
-- RFC PR: https://github.com/emberjs/rfcs/pull/45
-- Ember Issue: (leave this empty)
+---
+Start Date: 2015-06-07
+RFC PR: https://github.com/emberjs/rfcs/pull/45
+Ember Issue: (leave this empty)
+
+---
 
 # Summary
 

--- a/text/0045-internet-explorer.md
+++ b/text/0045-internet-explorer.md
@@ -1,7 +1,6 @@
 ---
 Start Date: 2015-06-07
 RFC PR: https://github.com/emberjs/rfcs/pull/45
-Ember Issue: (leave this empty)
 
 ---
 

--- a/text/0046-cli-improved-release-process.md
+++ b/text/0046-cli-improved-release-process.md
@@ -1,6 +1,9 @@
-- Start Date: 2016-03-26
-- Relevant Team(s): Ember CLI
-- RFC PR: [#46](https://github.com/ember-cli/rfcs/pull/29)
+---
+Start Date: 2016-03-26
+Relevant Team(s): Ember CLI
+RFC PR: #46
+
+---
 
 # Improved Release Process
  

--- a/text/0046-cli-improved-release-process.md
+++ b/text/0046-cli-improved-release-process.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2016-03-26
 Relevant Team(s): Ember CLI
-RFC PR: #46
+RFC PR: https://github.com/ember-cli/rfcs/pull/46
 
 ---
 

--- a/text/0046-registry-reform.md
+++ b/text/0046-registry-reform.md
@@ -1,6 +1,9 @@
-- Start Date: 2015-04-09
-- RFC PR: https://github.com/emberjs/rfcs/pull/46
-- Ember Issue: https://github.com/emberjs/ember.js/pull/11440
+---
+Start Date: 2015-04-09
+RFC PR: https://github.com/emberjs/rfcs/pull/46
+Ember Issue: https://github.com/emberjs/ember.js/pull/11440
+
+---
 
 # Summary
 

--- a/text/0050-cli-production-code-stripping.md
+++ b/text/0050-cli-production-code-stripping.md
@@ -1,6 +1,9 @@
-- Start Date: 2016-04-06
-- Relevant Team(s): Ember CLI
-- RFC PR: [#50](https://github.com/ember-cli/rfcs/pull/50)
+---
+Start Date: 2016-04-06
+Relevant Team(s): Ember CLI
+RFC PR: #50
+
+---
 
 # Summary
 

--- a/text/0050-cli-production-code-stripping.md
+++ b/text/0050-cli-production-code-stripping.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2016-04-06
 Relevant Team(s): Ember CLI
-RFC PR: #50
+RFC PR: https://github.com/ember-cli/rfcs/pull/50
 
 ---
 

--- a/text/0050-improved-actions.md
+++ b/text/0050-improved-actions.md
@@ -1,6 +1,9 @@
-- Start Date: 2014-05-06
-- RFC PR: https://github.com/emberjs/rfcs/pull/50
-- Ember Issue: (leave this empty)
+---
+Start Date: 2014-05-06
+RFC PR: https://github.com/emberjs/rfcs/pull/50
+Ember Issue: (leave this empty)
+
+---
 
 # Summary
 

--- a/text/0050-improved-actions.md
+++ b/text/0050-improved-actions.md
@@ -1,7 +1,6 @@
 ---
 Start Date: 2014-05-06
 RFC PR: https://github.com/emberjs/rfcs/pull/50
-Ember Issue: (leave this empty)
 
 ---
 

--- a/text/0053-helpers.md
+++ b/text/0053-helpers.md
@@ -1,6 +1,9 @@
-- Start Date: 2015-05-17
-- RFC PR: https://github.com/emberjs/rfcs/pull/53
-- Ember Issue: https://github.com/emberjs/ember.js/pull/11278
+---
+Start Date: 2015-05-17
+RFC PR: https://github.com/emberjs/rfcs/pull/53
+Ember Issue: https://github.com/emberjs/ember.js/pull/11278
+
+---
 
 # Summary
 

--- a/text/0055-anonymous-amd.md
+++ b/text/0055-anonymous-amd.md
@@ -1,6 +1,9 @@
-- Start Date: 2016-06-14
-- Relevant Team(s): Ember CLI
-- RFC PR: [#55](https://github.com/ember-cli/rfcs/pull/55)
+---
+Start Date: 2016-06-14
+Relevant Team(s): Ember CLI
+RFC PR: #55
+
+---
 
 # Summary
 

--- a/text/0055-anonymous-amd.md
+++ b/text/0055-anonymous-amd.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2016-06-14
 Relevant Team(s): Ember CLI
-RFC PR: #55
+RFC PR: https://github.com/ember-cli/rfcs/pull/55
 
 ---
 

--- a/text/0056-improved-release-cycle.md
+++ b/text/0056-improved-release-cycle.md
@@ -1,6 +1,9 @@
-- Start Date: 2015-10-02
-- RFC PR: https://github.com/emberjs/rfcs/pull/56
-- Ember Issue: (leave this empty)
+---
+Start Date: 2015-10-02
+RFC PR: https://github.com/emberjs/rfcs/pull/56
+Ember Issue: (leave this empty)
+
+---
 
 # Refining the Release Process
 

--- a/text/0056-improved-release-cycle.md
+++ b/text/0056-improved-release-cycle.md
@@ -1,7 +1,6 @@
 ---
 Start Date: 2015-10-02
 RFC PR: https://github.com/emberjs/rfcs/pull/56
-Ember Issue: (leave this empty)
 
 ---
 

--- a/text/0057-ember-data-reference-unification.md
+++ b/text/0057-ember-data-reference-unification.md
@@ -1,6 +1,9 @@
-- Start Date: 2015-05-20
-- RFC PR: https://github.com/emberjs/rfcs/pull/57
-- Ember Issue: https://github.com/emberjs/data/pull/3303
+---
+Start Date: 2015-05-20
+RFC PR: https://github.com/emberjs/rfcs/pull/57
+Ember Issue: https://github.com/emberjs/data/pull/3303
+
+---
 
 # Summary
 

--- a/text/0058-helper-listing.md
+++ b/text/0058-helper-listing.md
@@ -1,6 +1,9 @@
-- Start Date: 2015-05-24
-- RFC PR: https://github.com/emberjs/rfcs/pull/58
-- Ember Issue: https://github.com/emberjs/ember.js/pull/11393
+---
+Start Date: 2015-05-24
+RFC PR: https://github.com/emberjs/rfcs/pull/58
+Ember Issue: https://github.com/emberjs/ember.js/pull/11393
+
+---
 
 # Summary
 

--- a/text/0061-ember-data-background-fetch.md
+++ b/text/0061-ember-data-background-fetch.md
@@ -1,6 +1,9 @@
-- Start Date: 2015-06-03
-- RFC PR: https://github.com/emberjs/rfcs/pull/61
-- Ember Issue: This RFC is implemented over many Ember Data PRs
+---
+Start Date: 2015-06-03
+RFC PR: https://github.com/emberjs/rfcs/pull/61
+Ember Issue: This RFC is implemented over many Ember Data PRs
+
+---
 
 # Summary
 

--- a/text/0064-contextual-component-lookup.md
+++ b/text/0064-contextual-component-lookup.md
@@ -1,6 +1,9 @@
-- Start Date: 2015-06-12
-- RFC PR: https://github.com/emberjs/rfcs/pull/64
-- Ember Issue: (leave this empty)
+---
+Start Date: 2015-06-12
+RFC PR: https://github.com/emberjs/rfcs/pull/64
+Ember Issue: (leave this empty)
+
+---
 
 # Summary
 

--- a/text/0064-contextual-component-lookup.md
+++ b/text/0064-contextual-component-lookup.md
@@ -1,7 +1,6 @@
 ---
 Start Date: 2015-06-12
 RFC PR: https://github.com/emberjs/rfcs/pull/64
-Ember Issue: (leave this empty)
 
 ---
 

--- a/text/0065-deprecation-warning-handlers.md
+++ b/text/0065-deprecation-warning-handlers.md
@@ -1,6 +1,9 @@
-- Start Date: 2015-06-30
-- RFC PR: https://github.com/emberjs/rfcs/pull/65
-- Ember Issue: (leave this empty)
+---
+Start Date: 2015-06-30
+RFC PR: https://github.com/emberjs/rfcs/pull/65
+Ember Issue: (leave this empty)
+
+---
 
 # Summary
 

--- a/text/0065-deprecation-warning-handlers.md
+++ b/text/0065-deprecation-warning-handlers.md
@@ -1,7 +1,6 @@
 ---
 Start Date: 2015-06-30
 RFC PR: https://github.com/emberjs/rfcs/pull/65
-Ember Issue: (leave this empty)
 
 ---
 

--- a/text/0080-serve-file-api.md
+++ b/text/0080-serve-file-api.md
@@ -1,6 +1,9 @@
-- Start Date: 2016-11-21
-- Relevant Team(s): Ember CLI
-- RFC PR: [#80](https://github.com/ember-cli/rfcs/pull/80)
+---
+Start Date: 2016-11-21
+Relevant Team(s): Ember CLI
+RFC PR: #80
+
+---
 
 # Summary
 

--- a/text/0080-serve-file-api.md
+++ b/text/0080-serve-file-api.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2016-11-21
 Relevant Team(s): Ember CLI
-RFC PR: #80
+RFC PR: https://github.com/ember-cli/rfcs/pull/80
 
 ---
 

--- a/text/0086-firefox-in-ci.md
+++ b/text/0086-firefox-in-ci.md
@@ -1,6 +1,9 @@
-- Start Date: 2016-12-04
-- Relevant Team(s): Ember CLI
-- RFC PR: [#86](https://github.com/ember-cli/rfcs/pull/86)
+---
+Start Date: 2016-12-04
+Relevant Team(s): Ember CLI
+RFC PR: #86
+
+---
 
 # Summary
 

--- a/text/0086-firefox-in-ci.md
+++ b/text/0086-firefox-in-ci.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2016-12-04
 Relevant Team(s): Ember CLI
-RFC PR: #86
+RFC PR: https://github.com/ember-cli/rfcs/pull/86
 
 ---
 

--- a/text/0090-addon-tree-caching.md
+++ b/text/0090-addon-tree-caching.md
@@ -1,6 +1,9 @@
-- Start Date: 2016-12-11
-- Relevant Team(s): Ember CLI
-- RFC PR: [#90](https://github.com/ember-cli/rfcs/pull/90)
+---
+Start Date: 2016-12-11
+Relevant Team(s): Ember CLI
+RFC PR: #90
+
+---
 
 # Summary
 

--- a/text/0090-addon-tree-caching.md
+++ b/text/0090-addon-tree-caching.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2016-12-11
 Relevant Team(s): Ember CLI
-RFC PR: #90
+RFC PR: https://github.com/ember-cli/rfcs/pull/90
 
 ---
 

--- a/text/0091-cli-addon-instrumentation-experimental-hooks.md
+++ b/text/0091-cli-addon-instrumentation-experimental-hooks.md
@@ -1,6 +1,9 @@
-- Start Date: 2016-12-14
-- Relevant Team(s): Ember CLI
-- RFC PR: [#91](https://github.com/ember-cli/rfcs/pull/91)
+---
+Start Date: 2016-12-14
+Relevant Team(s): Ember CLI
+RFC PR: #91
+
+---
 
 # Summary
 

--- a/text/0091-cli-addon-instrumentation-experimental-hooks.md
+++ b/text/0091-cli-addon-instrumentation-experimental-hooks.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2016-12-14
 Relevant Team(s): Ember CLI
-RFC PR: #91
+RFC PR: https://github.com/ember-cli/rfcs/pull/91
 
 ---
 

--- a/text/0091-weakmap.md
+++ b/text/0091-weakmap.md
@@ -1,6 +1,9 @@
-- Start Date: 2015-09-11
-- RFC PR: https://github.com/emberjs/rfcs/pull/91
-- Ember Issue: [#12224](https://github.com/emberjs/ember.js/pull/12224) / [#12990](https://github.com/emberjs/ember.js/pull/12990) / [#13688](https://github.com/emberjs/ember.js/pull/13688)
+---
+Start Date: 2015-09-11
+RFC PR: https://github.com/emberjs/rfcs/pull/91
+Ember Issue: #12224 / #12990 / #13688
+
+---
 
 # Summary
 

--- a/text/0091-weakmap.md
+++ b/text/0091-weakmap.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2015-09-11
 RFC PR: https://github.com/emberjs/rfcs/pull/91
-Ember Issue: #12224 / #12990 / #13688
+Ember Issue: https://github.com/emberjs/ember.js/pull/12224 / https://github.com/emberjs/ember.js/pull/12990 / https://github.com/emberjs/ember.js/pull/13688
 
 ---
 

--- a/text/0092-blueprint-remove-old-files.md
+++ b/text/0092-blueprint-remove-old-files.md
@@ -1,6 +1,9 @@
-- Start Date: 2016-12-17
-- Relevant Team(s): Ember CLI
-- RFC PR: [#92](https://github.com/ember-cli/rfcs/pull/92)
+---
+Start Date: 2016-12-17
+Relevant Team(s): Ember CLI
+RFC PR: #92
+
+---
 
 # Summary
 

--- a/text/0092-blueprint-remove-old-files.md
+++ b/text/0092-blueprint-remove-old-files.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2016-12-17
 Relevant Team(s): Ember CLI
-RFC PR: #92
+RFC PR: https://github.com/ember-cli/rfcs/pull/92
 
 ---
 

--- a/text/0095-cli-standardise-targets.md
+++ b/text/0095-cli-standardise-targets.md
@@ -1,6 +1,9 @@
-- Start Date: 2017-01-03
-- Relevant Team(s): Ember CLI
-- RFC PR: [#95](https://github.com/ember-cli/rfcs/pull/95)
+---
+Start Date: 2017-01-03
+Relevant Team(s): Ember CLI
+RFC PR: #95
+
+---
 
 # Summary
 

--- a/text/0095-cli-standardise-targets.md
+++ b/text/0095-cli-standardise-targets.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2017-01-03
 Relevant Team(s): Ember CLI
-RFC PR: #95
+RFC PR: https://github.com/ember-cli/rfcs/pull/95
 
 ---
 

--- a/text/0095-router-service.md
+++ b/text/0095-router-service.md
@@ -1,6 +1,9 @@
-- Start Date: 2015-09-24
-- RFC PR: https://github.com/emberjs/rfcs/pull/95
-- Ember Issue: https://github.com/emberjs/ember.js/pull/14805
+---
+Start Date: 2015-09-24
+RFC PR: https://github.com/emberjs/rfcs/pull/95
+Ember Issue: https://github.com/emberjs/ember.js/pull/14805
+
+---
 
 # Summary
 

--- a/text/0096-enable-yarn-usage.md
+++ b/text/0096-enable-yarn-usage.md
@@ -1,6 +1,9 @@
-- Start Date: 2017-02-02
-- Relevant Team(s): Ember CLI
-- RFC PR: [#96](https://github.com/ember-cli/rfcs/pull/96)
+---
+Start Date: 2017-02-02
+Relevant Team(s): Ember CLI
+RFC PR: #96
+
+---
 
 # Summary
 

--- a/text/0096-enable-yarn-usage.md
+++ b/text/0096-enable-yarn-usage.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2017-02-02
 Relevant Team(s): Ember CLI
-RFC PR: #96
+RFC PR: https://github.com/ember-cli/rfcs/pull/96
 
 ---
 

--- a/text/0101-ember-data-friendly-errors.md
+++ b/text/0101-ember-data-friendly-errors.md
@@ -1,6 +1,9 @@
-- Start Date: 2015-10-23
-- RFC PR: https://github.com/emberjs/rfcs/pull/101
-- Ember Issue: https://github.com/emberjs/data/pull/3930
+---
+Start Date: 2015-10-23
+RFC PR: https://github.com/emberjs/rfcs/pull/101
+Ember Issue: https://github.com/emberjs/data/pull/3930
+
+---
 
 # Summary
 

--- a/text/0105-addons-optionalDependencies.md
+++ b/text/0105-addons-optionalDependencies.md
@@ -1,6 +1,9 @@
-- Start Date: 2017-4-23
-- Relevant Team(s): Ember CLI
-- RFC PR: [#105](https://github.com/ember-cli/rfcs/pull/105)
+---
+Start Date: 2017-4-23
+Relevant Team(s): Ember CLI
+RFC PR: #105
+
+---
 
 # Summary
 

--- a/text/0105-addons-optionalDependencies.md
+++ b/text/0105-addons-optionalDependencies.md
@@ -1,7 +1,7 @@
 ---
-Start Date: 2017-4-23
+Start Date: 2017-04-23
 Relevant Team(s): Ember CLI
-RFC PR: #105
+RFC PR: https://github.com/ember-cli/rfcs/pull/105
 
 ---
 

--- a/text/0108-add-custom-transform.md
+++ b/text/0108-add-custom-transform.md
@@ -1,6 +1,9 @@
-- Start Date: 2017-06-18
-- Relevant Team(s): Ember CLI
-- RFC PR: [#108](https://github.com/ember-cli/rfcs/pull/108)
+---
+Start Date: 2017-06-18
+Relevant Team(s): Ember CLI
+RFC PR: #108
+
+---
 
 # Summary
 

--- a/text/0108-add-custom-transform.md
+++ b/text/0108-add-custom-transform.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2017-06-18
 Relevant Team(s): Ember CLI
-RFC PR: #108
+RFC PR: https://github.com/ember-cli/rfcs/pull/108
 
 ---
 

--- a/text/0110-packaging.md
+++ b/text/0110-packaging.md
@@ -1,6 +1,9 @@
-- Start Date: 2017-09-07
-- Relevant Team(s): Ember CLI
-- RFC PR: [#110](https://github.com/ember-cli/rfcs/pull/110)
+---
+Start Date: 2017-09-07
+Relevant Team(s): Ember CLI
+RFC PR: #110
+
+---
 
 # Summary
 

--- a/text/0110-packaging.md
+++ b/text/0110-packaging.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2017-09-07
 Relevant Team(s): Ember CLI
-RFC PR: #110
+RFC PR: https://github.com/ember-cli/rfcs/pull/110
 
 ---
 

--- a/text/0114-add-template-lint-addon.md
+++ b/text/0114-add-template-lint-addon.md
@@ -1,6 +1,9 @@
-- Start Date: 2018-01-04
-- Relevant Team(s): Ember CLI
-- RFC PR: [#114](https://github.com/ember-cli/rfcs/pull/114)
+---
+Start Date: 2018-01-04
+Relevant Team(s): Ember CLI
+RFC PR: #114
+
+---
 
 # Summary
 

--- a/text/0114-add-template-lint-addon.md
+++ b/text/0114-add-template-lint-addon.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2018-01-04
 Relevant Team(s): Ember CLI
-RFC PR: #114
+RFC PR: https://github.com/ember-cli/rfcs/pull/114
 
 ---
 

--- a/text/0116-qunit-dom.md
+++ b/text/0116-qunit-dom.md
@@ -1,6 +1,9 @@
-- Start Date: 2018-02-12
-- Relevant Team(s): Ember CLI
-- RFC PR: [#116](https://github.com/ember-cli/rfcs/pull/116)
+---
+Start Date: 2018-02-12
+Relevant Team(s): Ember CLI
+RFC PR: #116
+
+---
 
 # Summary
 

--- a/text/0116-qunit-dom.md
+++ b/text/0116-qunit-dom.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2018-02-12
 Relevant Team(s): Ember CLI
-RFC PR: #116
+RFC PR: https://github.com/ember-cli/rfcs/pull/116
 
 ---
 

--- a/text/0120-cli-guides.md
+++ b/text/0120-cli-guides.md
@@ -1,6 +1,9 @@
-- Start Date: 2018-07-30
-- Relevant Team(s): Ember CLI
-- RFC PR: [#120](https://github.com/ember-cli/rfcs/pull/120)
+---
+Start Date: 2018-07-30
+Relevant Team(s): Ember CLI
+RFC PR: #120
+
+---
 
 # Ember CLI Docs
 

--- a/text/0120-cli-guides.md
+++ b/text/0120-cli-guides.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2018-07-30
 Relevant Team(s): Ember CLI
-RFC PR: #120
+RFC PR: https://github.com/ember-cli/rfcs/pull/120
 
 ---
 

--- a/text/0120-route-serializers.md
+++ b/text/0120-route-serializers.md
@@ -1,6 +1,9 @@
-- Start Date: 2016-02-11
-- RFC PR: [emberjs/rfcs#120](https://github.com/emberjs/rfcs/pull/120)
-- Ember Issue: https://github.com/emberjs/ember.js/pull/13016
+---
+Start Date: 2016-02-11
+RFC PR: emberjs/rfcs#120
+Ember Issue: https://github.com/emberjs/ember.js/pull/13016
+
+---
 
 # Summary
 

--- a/text/0120-route-serializers.md
+++ b/text/0120-route-serializers.md
@@ -1,6 +1,6 @@
 ---
 Start Date: 2016-02-11
-RFC PR: emberjs/rfcs#120
+RFC PR: https://github.com/emberjs/rfcs/pull/120
 Ember Issue: https://github.com/emberjs/ember.js/pull/13016
 
 ---

--- a/text/0121-remove-ember-cli-eslint.md
+++ b/text/0121-remove-ember-cli-eslint.md
@@ -1,6 +1,9 @@
-- Start Date: 2018-08-13
-- Relevant Team(s): Ember CLI
-- RFC PR: [#121](https://github.com/ember-cli/rfcs/pull/121)
+---
+Start Date: 2018-08-13
+Relevant Team(s): Ember CLI
+RFC PR: #121
+
+---
 
 # Summary
 

--- a/text/0121-remove-ember-cli-eslint.md
+++ b/text/0121-remove-ember-cli-eslint.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2018-08-13
 Relevant Team(s): Ember CLI
-RFC PR: #121
+RFC PR: https://github.com/ember-cli/rfcs/pull/121
 
 ---
 

--- a/text/0136-contains-to-includes.md
+++ b/text/0136-contains-to-includes.md
@@ -1,6 +1,9 @@
-- Start Date: 2016-04-16
-- RFC PR: https://github.com/emberjs/rfcs/pull/136
-- Ember Issue: https://github.com/emberjs/ember.js/pull/13553
+---
+Start Date: 2016-04-16
+RFC PR: https://github.com/emberjs/rfcs/pull/136
+Ember Issue: https://github.com/emberjs/ember.js/pull/13553
+
+---
 
 # Summary
 

--- a/text/0139-isHtmlSafe.md
+++ b/text/0139-isHtmlSafe.md
@@ -1,6 +1,9 @@
-- Start Date: 2016-04-18
-- RFC PR: [#139](https://github.com/emberjs/rfcs/pull/139)
-- Ember Issue: [emberjs/ember.js#13666](https://github.com/emberjs/ember.js/pull/13666)
+---
+Start Date: 2016-04-18
+RFC PR: #139
+Ember Issue: emberjs/ember.js#13666
+
+---
 
 # Summary
 

--- a/text/0139-isHtmlSafe.md
+++ b/text/0139-isHtmlSafe.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2016-04-18
-RFC PR: #139
-Ember Issue: emberjs/ember.js#13666
+RFC PR: https://github.com/emberjs/rfcs/pull/139
+Ember Issue: https://github.com/emberjs/ember.js/pull/13666
 
 ---
 

--- a/text/0143-module-unification.md
+++ b/text/0143-module-unification.md
@@ -1,7 +1,10 @@
-- Start Date: 2016-05-09
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/143
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/27 / https://github.com/emberjs/ember.js/issues/14882
+---
+Start Date: 2016-05-09
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/143
+Tracking: https://github.com/emberjs/rfc-tracking/issues/27 / https://github.com/emberjs/ember.js/issues/14882
+
+---
 
 > Note: This RFC replaces the closely related RFC for [Module
 Normalization](https://github.com/emberjs/rfcs/pull/124). As discussed in the

--- a/text/0150-factory-for.md
+++ b/text/0150-factory-for.md
@@ -1,6 +1,9 @@
-- Start Date: 2016-06-11
-- RFC PR: [#150](https://github.com/emberjs/rfcs/pull/150)
-- Ember Issue: [#14360](https://github.com/emberjs/ember.js/pull/14360)
+---
+Start Date: 2016-06-11
+RFC PR: #150
+Ember Issue: #14360
+
+---
 
 # Summary
 

--- a/text/0150-factory-for.md
+++ b/text/0150-factory-for.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2016-06-11
-RFC PR: #150
-Ember Issue: #14360
+RFC PR: https://github.com/emberjs/rfcs/pull/150
+Ember Issue: https://github.com/emberjs/ember.js/pull/14360
 
 ---
 

--- a/text/0176-javascript-module-api.md
+++ b/text/0176-javascript-module-api.md
@@ -1,6 +1,9 @@
-- Start Date: 2016-11-05
-- RFC PR: https://github.com/emberjs/rfcs/pull/176
-- Ember Issue: (leave this empty)
+---
+Start Date: 2016-11-05
+RFC PR: https://github.com/emberjs/rfcs/pull/176
+Ember Issue: (leave this empty)
+
+---
 
 # Summary
 

--- a/text/0176-javascript-module-api.md
+++ b/text/0176-javascript-module-api.md
@@ -1,7 +1,6 @@
 ---
 Start Date: 2016-11-05
 RFC PR: https://github.com/emberjs/rfcs/pull/176
-Ember Issue: (leave this empty)
 
 ---
 

--- a/text/0178-deprecate-ember-k.md
+++ b/text/0178-deprecate-ember-k.md
@@ -1,6 +1,9 @@
-- Start Date: 2016-11-18
-- RFC PR: [#178](https://github.com/emberjs/rfcs/pull/178)
-- Ember Issue: [#14746](https://github.com/emberjs/ember.js/issues/14746)
+---
+Start Date: 2016-11-18
+RFC PR: #178
+Ember Issue: #14746
+
+---
 
 # Summary
 

--- a/text/0178-deprecate-ember-k.md
+++ b/text/0178-deprecate-ember-k.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2016-11-18
-RFC PR: #178
-Ember Issue: #14746
+RFC PR: https://github.com/emberjs/rfcs/pull/178
+Ember Issue: https://github.com/emberjs/ember.js/issues/14746
 
 ---
 

--- a/text/0181-deprecate-ember-data-initializers.md
+++ b/text/0181-deprecate-ember-data-initializers.md
@@ -1,6 +1,9 @@
-- Start Date: 2016-11-22
-- RFC PR: (leave this empty)
-- Ember Issue: (leave this empty)
+---
+Start Date: 2016-11-22
+RFC PR: (leave this empty)
+Ember Issue: (leave this empty)
+
+---
 
 # Summary
 

--- a/text/0181-deprecate-ember-data-initializers.md
+++ b/text/0181-deprecate-ember-data-initializers.md
@@ -1,7 +1,6 @@
 ---
 Start Date: 2016-11-22
-RFC PR: (leave this empty)
-Ember Issue: (leave this empty)
+RFC PR: https://github.com/emberjs/rfcs/pull/181
 
 ---
 

--- a/text/0186-track-unique-history-location-state.md
+++ b/text/0186-track-unique-history-location-state.md
@@ -1,6 +1,9 @@
-- Start Date: 2016/12/05
-- RFC PR: https://github.com/emberjs/rfcs/pull/186
-- Ember Issue: (leave this empty)
+---
+Start Date: 2016/12/05
+RFC PR: https://github.com/emberjs/rfcs/pull/186
+Ember Issue: (leave this empty)
+
+---
 
 # Summary
 

--- a/text/0186-track-unique-history-location-state.md
+++ b/text/0186-track-unique-history-location-state.md
@@ -1,7 +1,6 @@
 ---
-Start Date: 2016/12/05
+Start Date: 2016-12-05
 RFC PR: https://github.com/emberjs/rfcs/pull/186
-Ember Issue: (leave this empty)
 
 ---
 

--- a/text/0191-deprecate-component-lifecycle-hook-args.md
+++ b/text/0191-deprecate-component-lifecycle-hook-args.md
@@ -1,6 +1,9 @@
-- Start Date: 2016-12-14
-- RFC PR: [#191](https://github.com/emberjs/rfcs/pull/191)
-- Ember Issue: [#14711](https://github.com/emberjs/ember.js/pull/14711)
+---
+Start Date: 2016-12-14
+RFC PR: #191
+Ember Issue: #14711
+
+---
 
 # Summary
 

--- a/text/0191-deprecate-component-lifecycle-hook-args.md
+++ b/text/0191-deprecate-component-lifecycle-hook-args.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2016-12-14
-RFC PR: #191
-Ember Issue: #14711
+RFC PR: https://github.com/emberjs/rfcs/pull/191
+Ember Issue: https://github.com/emberjs/ember.js/pull/14711
 
 ---
 

--- a/text/0194-deprecate-custom-event-manager.md
+++ b/text/0194-deprecate-custom-event-manager.md
@@ -1,6 +1,9 @@
-- Start Date: 2016-12-24
-- RFC PR: https://github.com/emberjs/rfcs/pull/194
-- Ember Issue: https://github.com/emberjs/ember.js/issues/14754
+---
+Start Date: 2016-12-24
+RFC PR: https://github.com/emberjs/rfcs/pull/194
+Ember Issue: https://github.com/emberjs/ember.js/issues/14754
+
+---
 
 # Summary
 

--- a/text/0213-custom-components.md
+++ b/text/0213-custom-components.md
@@ -1,6 +1,9 @@
-- Start Date: 2017-03-13
-- RFC PR: https://github.com/emberjs/rfcs/pull/213
-- Ember Issue: https://github.com/emberjs/ember.js/issues/16301
+---
+Start Date: 2017-03-13
+RFC PR: https://github.com/emberjs/rfcs/pull/213
+Ember Issue: https://github.com/emberjs/ember.js/issues/16301
+
+---
 
 # Summary
 

--- a/text/0225-ember-engines-mount-params.md
+++ b/text/0225-ember-engines-mount-params.md
@@ -1,6 +1,9 @@
-- Start Date: 2017-04-26
-- RFC PR: [#15174](https://github.com/emberjs/ember.js/pull/15174)
-- Ember Issue: (leave this empty)
+---
+Start Date: 2017-04-26
+RFC PR: #15174
+Ember Issue: (leave this empty)
+
+---
 
 # Summary
 

--- a/text/0225-ember-engines-mount-params.md
+++ b/text/0225-ember-engines-mount-params.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2017-04-26
-RFC PR: #15174
-Ember Issue: (leave this empty)
+RFC PR: https://github.com/emberjs/rfcs/pull/225
+Ember Issue: https://github.com/emberjs/ember.js/pull/15174
 
 ---
 

--- a/text/0226-named-blocks.md
+++ b/text/0226-named-blocks.md
@@ -1,7 +1,10 @@
-- Start Date: 2017-05-05
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/226
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/13
+---
+Start Date: 2017-05-05
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/226
+Tracking: https://github.com/emberjs/rfc-tracking/issues/13
+
+---
 
 # Summary
 

--- a/text/0229-deprecate-testing-restricted-resolver.md
+++ b/text/0229-deprecate-testing-restricted-resolver.md
@@ -1,6 +1,9 @@
-- Start Date: 2017-06-11
-- RFC PR: [emberjs/rfcs#229](https://github.com/emberjs/rfcs/pull/229)
-- Ember Issue: (leave this empty)
+---
+Start Date: 2017-06-11
+RFC PR: emberjs/rfcs#229
+Ember Issue: (leave this empty)
+
+---
 
 # Summary
 

--- a/text/0229-deprecate-testing-restricted-resolver.md
+++ b/text/0229-deprecate-testing-restricted-resolver.md
@@ -1,7 +1,6 @@
 ---
 Start Date: 2017-06-11
-RFC PR: emberjs/rfcs#229
-Ember Issue: (leave this empty)
+RFC PR: https://github.com/emberjs/rfcs/pull/229
 
 ---
 

--- a/text/0232-simplify-qunit-testing-api.md
+++ b/text/0232-simplify-qunit-testing-api.md
@@ -1,6 +1,9 @@
-- Start Date: 2017-06-13
-- RFC PR: [emberjs/rfcs#232](https://github.com/emberjs/rfcs/pull/232)
-- Ember Issue: (leave this empty)
+---
+Start Date: 2017-06-13
+RFC PR: emberjs/rfcs#232
+Ember Issue: (leave this empty)
+
+---
 
 # Summary
 

--- a/text/0232-simplify-qunit-testing-api.md
+++ b/text/0232-simplify-qunit-testing-api.md
@@ -1,7 +1,6 @@
 ---
 Start Date: 2017-06-13
-RFC PR: emberjs/rfcs#232
-Ember Issue: (leave this empty)
+RFC PR: https://github.com/emberjs/rfcs/pull/232
 
 ---
 

--- a/text/0236-deprecation-ember-string.md
+++ b/text/0236-deprecation-ember-string.md
@@ -1,7 +1,10 @@
-- Start Date: 2017-07-14
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/236
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/26
+---
+Start Date: 2017-07-14
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/236
+Tracking: https://github.com/emberjs/rfc-tracking/issues/26
+
+---
 
 # Summary
 

--- a/text/0237-deprecation-ember-map.md
+++ b/text/0237-deprecation-ember-map.md
@@ -1,6 +1,9 @@
-- Start Date: 2017-07-20
-- RFC PR: https://github.com/emberjs/rfcs/pull/237
-- Ember Issue: (leave this empty)
+---
+Start Date: 2017-07-20
+RFC PR: https://github.com/emberjs/rfcs/pull/237
+Ember Issue: (leave this empty)
+
+---
 
 # Summary
 

--- a/text/0237-deprecation-ember-map.md
+++ b/text/0237-deprecation-ember-map.md
@@ -1,7 +1,6 @@
 ---
 Start Date: 2017-07-20
 RFC PR: https://github.com/emberjs/rfcs/pull/237
-Ember Issue: (leave this empty)
 
 ---
 

--- a/text/0240-es-classes.md
+++ b/text/0240-es-classes.md
@@ -1,6 +1,9 @@
-- Start Date: 2017-07-28
-- RFC PR: [#240](https://github.com/emberjs/rfcs/pull/240)
-- Ember Issue: (leave this empty)
+---
+Start Date: 2017-07-28
+RFC PR: #240
+Ember Issue: (leave this empty)
+
+---
 
 # Summary
 

--- a/text/0240-es-classes.md
+++ b/text/0240-es-classes.md
@@ -1,7 +1,6 @@
 ---
 Start Date: 2017-07-28
-RFC PR: #240
-Ember Issue: (leave this empty)
+RFC PR: https://github.com/emberjs/rfcs/pull/240
 
 ---
 

--- a/text/0252-browser-support-changes.md
+++ b/text/0252-browser-support-changes.md
@@ -1,8 +1,9 @@
-# Browser Support Changes
+---
+Start Date: 2017-09-25
+RFC PR: (leave this empty)
+Ember Issue: (leave this empty)
 
-- Start Date: 2017-09-25
-- RFC PR: (leave this empty)
-- Ember Issue: (leave this empty)
+---
 
 # Summary
 

--- a/text/0252-browser-support-changes.md
+++ b/text/0252-browser-support-changes.md
@@ -1,7 +1,6 @@
 ---
 Start Date: 2017-09-25
-RFC PR: (leave this empty)
-Ember Issue: (leave this empty)
+RFC PR: https://github.com/emberjs/rfcs/pull/252
 
 ---
 

--- a/text/0268-acceptance-testing-refactor.md
+++ b/text/0268-acceptance-testing-refactor.md
@@ -1,6 +1,9 @@
-- Start Date: 2017-11-05
-- RFC PR: [emberjs/rfcs#268](https://github.com/emberjs/rfcs/pull/268)
-- Ember Issue: (leave this empty)
+---
+Start Date: 2017-11-05
+RFC PR: emberjs/rfcs#268
+Ember Issue: (leave this empty)
+
+---
 
 # Summary
 

--- a/text/0268-acceptance-testing-refactor.md
+++ b/text/0268-acceptance-testing-refactor.md
@@ -1,7 +1,6 @@
 ---
 Start Date: 2017-11-05
-RFC PR: emberjs/rfcs#268
-Ember Issue: (leave this empty)
+RFC PR: https://github.com/emberjs/rfcs/pull/268
 
 ---
 

--- a/text/0272-deprecation-native-function-prototype-extensions.md
+++ b/text/0272-deprecation-native-function-prototype-extensions.md
@@ -1,7 +1,10 @@
-- Start Date: 2017-11-20
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/272
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/12
+---
+Start Date: 2017-11-20
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/272
+Tracking: https://github.com/emberjs/rfc-tracking/issues/12
+
+---
 
 # Deprecate Function.prototype.on, Function.prototype.observes and Function.prototype.property
 

--- a/text/0276-named-args.md
+++ b/text/0276-named-args.md
@@ -1,6 +1,9 @@
-- Start Date: 2017-12-10
-- RFC PR: https://github.com/emberjs/rfcs/pull/276
-- Ember Issue: https://github.com/emberjs/ember.js/pull/15968
+---
+Start Date: 2017-12-10
+RFC PR: https://github.com/emberjs/rfcs/pull/276
+Ember Issue: https://github.com/emberjs/ember.js/pull/15968
+
+---
 
 # Summary
 

--- a/text/0278-template-only-components.md
+++ b/text/0278-template-only-components.md
@@ -1,6 +1,9 @@
-- Start Date: 2017-12-11
-- RFC PR: https://github.com/emberjs/rfcs/pull/278
-- Ember Issue: https://github.com/emberjs/ember.js/pull/15974
+---
+Start Date: 2017-12-11
+RFC PR: https://github.com/emberjs/rfcs/pull/278
+Ember Issue: https://github.com/emberjs/ember.js/pull/15974
+
+---
 
 # Summary
 

--- a/text/0280-remove-application-wrapper.md
+++ b/text/0280-remove-application-wrapper.md
@@ -1,6 +1,9 @@
-- Start Date: 2017-12-11
-- RFC PR: https://github.com/emberjs/rfcs/pull/280
-- Ember Issue: https://github.com/emberjs/ember.js/pull/15981
+---
+Start Date: 2017-12-11
+RFC PR: https://github.com/emberjs/rfcs/pull/280
+Ember Issue: https://github.com/emberjs/ember.js/pull/15981
+
+---
 
 # Summary
 

--- a/text/0281-es5-getters.md
+++ b/text/0281-es5-getters.md
@@ -1,6 +1,9 @@
-- Start Date: 2017-12-12
-- RFC PR: https://github.com/emberjs/rfcs/pull/281
-- Ember Issue: (leave this empty)
+---
+Start Date: 2017-12-12
+RFC PR: https://github.com/emberjs/rfcs/pull/281
+Ember Issue: (leave this empty)
+
+---
 
 # Summary
 

--- a/text/0281-es5-getters.md
+++ b/text/0281-es5-getters.md
@@ -1,7 +1,6 @@
 ---
 Start Date: 2017-12-12
 RFC PR: https://github.com/emberjs/rfcs/pull/281
-Ember Issue: (leave this empty)
 
 ---
 

--- a/text/0286-block-let-template-helper.md
+++ b/text/0286-block-let-template-helper.md
@@ -1,6 +1,9 @@
-* Start Date: 2017-12-21
-* RFC PR: https://github.com/emberjs/rfcs/pull/286
-* Ember Issue: https://github.com/emberjs/ember.js/pull/16076
+---
+Start Date: 2017-12-21
+RFC PR: https://github.com/emberjs/rfcs/pull/286
+Ember Issue: https://github.com/emberjs/ember.js/pull/16076
+
+---
 
 # Block `let` template helper
 

--- a/text/0287-promote-in-element-to-public-api.md
+++ b/text/0287-promote-in-element-to-public-api.md
@@ -1,7 +1,10 @@
-- Start Date: 2017-12-22
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/287
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/25
+---
+Start Date: 2017-12-22
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/287
+Tracking: https://github.com/emberjs/rfc-tracking/issues/25
+
+---
 
 # Summary
 

--- a/text/0293-record-data.md
+++ b/text/0293-record-data.md
@@ -1,7 +1,10 @@
-- Start Date: 2018-01-10 
-- Relevant Team(s): Ember Data
-- RFC PR: github.com/emberjs/rfcs/pull/293
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/24
+---
+Start Date: 2018-01-10
+Relevant Team(s): Ember Data
+RFC PR: github.com/emberjs/rfcs/pull/293
+Tracking: https://github.com/emberjs/rfc-tracking/issues/24
+
+---
 
 ### Summary
 

--- a/text/0293-record-data.md
+++ b/text/0293-record-data.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2018-01-10
 Relevant Team(s): Ember Data
-RFC PR: github.com/emberjs/rfcs/pull/293
+RFC PR: https://github.com/emberjs/rfcs/pull/293
 Tracking: https://github.com/emberjs/rfc-tracking/issues/24
 
 ---

--- a/text/0294-optional-jquery.md
+++ b/text/0294-optional-jquery.md
@@ -1,6 +1,9 @@
-- Start Date: 2018-01-11
-- RFC PR: github.com/emberjs/rfcs/pull/294
-- Ember Issue: (leave this empty)
+---
+Start Date: 2018-01-11
+RFC PR: github.com/emberjs/rfcs/pull/294
+Ember Issue: (leave this empty)
+
+---
 
 # Make jQuery optional
 

--- a/text/0294-optional-jquery.md
+++ b/text/0294-optional-jquery.md
@@ -1,7 +1,6 @@
 ---
 Start Date: 2018-01-11
-RFC PR: github.com/emberjs/rfcs/pull/294
-Ember Issue: (leave this empty)
+RFC PR: https://github.com/emberjs/rfcs/pull/294
 
 ---
 

--- a/text/0297-deprecate-ember-logger.md
+++ b/text/0297-deprecate-ember-logger.md
@@ -1,6 +1,9 @@
-- 2018-01-17
-- RFC PR: 0297
-- Ember Issue: https://github.com/emberjs/ember.js/issues/16231
+---
+2018-01-17: 
+RFC PR: 0297
+Ember Issue: https://github.com/emberjs/ember.js/issues/16231
+
+---
 
 # Deprecation of Ember.Logger
 

--- a/text/0297-deprecate-ember-logger.md
+++ b/text/0297-deprecate-ember-logger.md
@@ -1,6 +1,6 @@
 ---
-2018-01-17: 
-RFC PR: 0297
+Start Date: 2018-01-17 
+RFC PR: https://github.com/emberjs/rfcs/pull/297
 Ember Issue: https://github.com/emberjs/ember.js/issues/16231
 
 ---

--- a/text/0300-rfc-process-update.md
+++ b/text/0300-rfc-process-update.md
@@ -1,7 +1,10 @@
-- Start Date: 2018-02-04
-- Relevant Team(s): Steering
-- RFC PR: https://github.com/emberjs/rfcs/pull/300
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/1
+---
+Start Date: 2018-02-04
+Relevant Team(s): Steering
+RFC PR: https://github.com/emberjs/rfcs/pull/300
+Tracking: https://github.com/emberjs/rfc-tracking/issues/1
+
+---
 
 # RFC (Request for Comments) Process Update
 

--- a/text/0308-deprecate-property-lookup-fallback.md
+++ b/text/0308-deprecate-property-lookup-fallback.md
@@ -1,6 +1,9 @@
-- Start Date: 2018-02-15
-- RFC PR: https://github.com/emberjs/rfcs/pull/308
-- Ember Issue:
+---
+Start Date: 2018-02-15
+RFC PR: https://github.com/emberjs/rfcs/pull/308
+Ember Issue: 
+
+---
 
 # Summary
 

--- a/text/0308-deprecate-property-lookup-fallback.md
+++ b/text/0308-deprecate-property-lookup-fallback.md
@@ -1,7 +1,6 @@
 ---
 Start Date: 2018-02-15
 RFC PR: https://github.com/emberjs/rfcs/pull/308
-Ember Issue: 
 
 ---
 

--- a/text/0311-angle-bracket-invocation.md
+++ b/text/0311-angle-bracket-invocation.md
@@ -1,6 +1,9 @@
-- Start Date: 2018-03-09
-- RFC PR: https://github.com/emberjs/rfcs/pull/311
-- Ember Issue: (leave this empty)
+---
+Start Date: 2018-03-09
+RFC PR: https://github.com/emberjs/rfcs/pull/311
+Ember Issue: (leave this empty)
+
+---
 
 # Angle Bracket Invocation
 

--- a/text/0311-angle-bracket-invocation.md
+++ b/text/0311-angle-bracket-invocation.md
@@ -1,7 +1,6 @@
 ---
 Start Date: 2018-03-09
 RFC PR: https://github.com/emberjs/rfcs/pull/311
-Ember Issue: (leave this empty)
 
 ---
 

--- a/text/0318-array-helper.md
+++ b/text/0318-array-helper.md
@@ -1,7 +1,10 @@
-- Start Date: 2018-03-24
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/318
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/23
+---
+Start Date: 2018-03-24
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/318
+Tracking: https://github.com/emberjs/rfc-tracking/issues/23
+
+---
 
 # `array` helper
 

--- a/text/0322-deprecate-copy-copyable.md
+++ b/text/0322-deprecate-copy-copyable.md
@@ -1,6 +1,9 @@
-- 2018-03-24
-- RFC PR: 322
-- Ember Issue: (leave this empty)
+---
+2018-03-24: 
+RFC PR: 322
+Ember Issue: (leave this empty)
+
+---
 
 # Deprecation of Ember.copy and Ember.Copyable
 

--- a/text/0322-deprecate-copy-copyable.md
+++ b/text/0322-deprecate-copy-copyable.md
@@ -1,7 +1,6 @@
 ---
-2018-03-24: 
-RFC PR: 322
-Ember Issue: (leave this empty)
+Start Date: 2018-03-24 
+RFC PR: https://github.com/emberjs/rfcs/pull/322
 
 ---
 

--- a/text/0324-deprecate-component-isvisible.md
+++ b/text/0324-deprecate-component-isvisible.md
@@ -1,7 +1,10 @@
-- Start Date: 2018-03-28
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/324
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/22
+---
+Start Date: 2018-03-28
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/324
+Tracking: https://github.com/emberjs/rfc-tracking/issues/22
+
+---
 
 # Summary
 

--- a/text/0326-ember-data-filter-deprecation.md
+++ b/text/0326-ember-data-filter-deprecation.md
@@ -1,6 +1,9 @@
-- Start Date: (fill me in with today's date, 2018-04-18)
-- RFC PR: #326
-- Ember Issue: (leave this empty)
+---
+Start Date: (fill me in with today's date, 2018-04-18)
+RFC PR: #326
+Ember Issue: (leave this empty)
+
+---
 
 # Ember Data Filter Deprecation
 

--- a/text/0326-ember-data-filter-deprecation.md
+++ b/text/0326-ember-data-filter-deprecation.md
@@ -1,7 +1,6 @@
 ---
-Start Date: (fill me in with today's date, 2018-04-18)
-RFC PR: #326
-Ember Issue: (leave this empty)
+Start Date: 2018-04-18
+RFC PR: https://github.com/emberjs/rfcs/pull/326
 
 ---
 

--- a/text/0329-deprecated-ember-evented-in-ember-data.md
+++ b/text/0329-deprecated-ember-evented-in-ember-data.md
@@ -1,7 +1,10 @@
-- Start Date: 2018-05-01
-- Relevant Team(s): Ember Data
-- RFC PR: https://github.com/emberjs/rfcs/pull/329
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/21
+---
+Start Date: 2018-05-01
+Relevant Team(s): Ember Data
+RFC PR: https://github.com/emberjs/rfcs/pull/329
+Tracking: https://github.com/emberjs/rfc-tracking/issues/21
+
+---
 
 # Deprecate Usage of Ember Evented in Ember Data
 

--- a/text/0331-deprecate-globals-resolver.md
+++ b/text/0331-deprecate-globals-resolver.md
@@ -1,7 +1,10 @@
-- Start Date: 2018-05-08
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/331
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/20
+---
+Start Date: 2018-05-08
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/331
+Tracking: https://github.com/emberjs/rfc-tracking/issues/20
+
+---
 
 # Summary
 

--- a/text/0332-ember-data-record-links-and-meta.md
+++ b/text/0332-ember-data-record-links-and-meta.md
@@ -1,7 +1,10 @@
-- Start Date: 2018-10-24
-- Relevant Team(s): Ember Data
-- RFC PR: https://github.com/emberjs/rfcs/pull/332
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/19
+---
+Start Date: 2018-10-24
+Relevant Team(s): Ember Data
+RFC PR: https://github.com/emberjs/rfcs/pull/332
+Tracking: https://github.com/emberjs/rfc-tracking/issues/19
+
+---
 
 # Ember Data Record Links & Meta
 

--- a/text/0335-deprecate-send-action.md
+++ b/text/0335-deprecate-send-action.md
@@ -1,6 +1,9 @@
-- Start Date: 2018-05-29
-- RFC PR: https://github.com/emberjs/rfcs/pull/335
-- Ember Issue: (leave this empty)
+---
+Start Date: 2018-05-29
+RFC PR: https://github.com/emberjs/rfcs/pull/335
+Ember Issue: (leave this empty)
+
+---
 
 # Deprecate `.sendAction`
 

--- a/text/0335-deprecate-send-action.md
+++ b/text/0335-deprecate-send-action.md
@@ -1,7 +1,6 @@
 ---
 Start Date: 2018-05-29
 RFC PR: https://github.com/emberjs/rfcs/pull/335
-Ember Issue: (leave this empty)
 
 ---
 

--- a/text/0337-native-class-constructor-update.md
+++ b/text/0337-native-class-constructor-update.md
@@ -1,6 +1,9 @@
-- Start Date: 2018-06-14
-- RFC PR: https://github.com/emberjs/rfcs/pull/337
-- Ember Issue: https://github.com/emberjs/ember.js/pull/16795
+---
+Start Date: 2018-06-14
+RFC PR: https://github.com/emberjs/rfcs/pull/337
+Ember Issue: https://github.com/emberjs/ember.js/pull/16795
+
+---
 
 # Native Class Constructor Update
 

--- a/text/0340-deprecate-ember-merge.md
+++ b/text/0340-deprecate-ember-merge.md
@@ -1,6 +1,9 @@
-- Start Date: 2018-06-19
-- RFC PR: https://github.com/emberjs/rfcs/pull/340
-- Ember Issue: (leave this empty)
+---
+Start Date: 2018-06-19
+RFC PR: https://github.com/emberjs/rfcs/pull/340
+Ember Issue: (leave this empty)
+
+---
 
 # Deprecate Ember.merge in favor of Ember.assign
 

--- a/text/0340-deprecate-ember-merge.md
+++ b/text/0340-deprecate-ember-merge.md
@@ -1,7 +1,6 @@
 ---
 Start Date: 2018-06-19
 RFC PR: https://github.com/emberjs/rfcs/pull/340
-Ember Issue: (leave this empty)
 
 ---
 

--- a/text/0345-discord.md
+++ b/text/0345-discord.md
@@ -1,6 +1,9 @@
-- Start Date: 07/11/2018
-- RFC PR: https://github.com/emberjs/rfcs/pull/345
-- Ember Issue: (leave this empty)
+---
+Start Date: 07/11/2018
+RFC PR: https://github.com/emberjs/rfcs/pull/345
+Ember Issue: (leave this empty)
+
+---
 
 # RFC to move the Ember community chat to Discord
 

--- a/text/0345-discord.md
+++ b/text/0345-discord.md
@@ -1,7 +1,6 @@
 ---
-Start Date: 07/11/2018
+Start Date: 2019-07-11
 RFC PR: https://github.com/emberjs/rfcs/pull/345
-Ember Issue: (leave this empty)
 
 ---
 

--- a/text/0364-roadmap-2018.md
+++ b/text/0364-roadmap-2018.md
@@ -1,6 +1,9 @@
-- Start Date: 2018-08-24
-- RFC PR: https://github.com/emberjs/rfcs/pull/364
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/28
+---
+Start Date: 2018-08-24
+RFC PR: https://github.com/emberjs/rfcs/pull/364
+Tracking: https://github.com/emberjs/rfc-tracking/issues/28
+
+---
 
 # Ember 2018 Roadmap RFC
 

--- a/text/0369-deprecate-computed-clobberability.md
+++ b/text/0369-deprecate-computed-clobberability.md
@@ -1,7 +1,10 @@
-- Start Date: 2018-08-30
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/369
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/18
+---
+Start Date: 2018-08-30
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/369
+Tracking: https://github.com/emberjs/rfc-tracking/issues/18
+
+---
 
 # Summary
 

--- a/text/0370-deprecate-computed-volatile.md
+++ b/text/0370-deprecate-computed-volatile.md
@@ -1,7 +1,10 @@
-- Start Date: 2018-08-31
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/370
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/17
+---
+Start Date: 2018-08-31
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/370
+Tracking: https://github.com/emberjs/rfc-tracking/issues/17
+
+---
 
 # Summary
 

--- a/text/0372-ember-data-model-factory-for.md
+++ b/text/0372-ember-data-model-factory-for.md
@@ -1,7 +1,10 @@
-- Start Date: 2018-09-06
-- Relevant Team(s): Ember Data
-- RFC PR: https://github.com/emberjs/rfcs/pull/372
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/16
+---
+Start Date: 2018-09-06
+Relevant Team(s): Ember Data
+RFC PR: https://github.com/emberjs/rfcs/pull/372
+Tracking: https://github.com/emberjs/rfc-tracking/issues/16
+
+---
 
 # ember-data | modelFactoryFor
 

--- a/text/0373-Element-Modifier-Managers.md
+++ b/text/0373-Element-Modifier-Managers.md
@@ -1,6 +1,9 @@
-- Start Date: 2018-09-10
-- RFC PR: https://github.com/emberjs/rfcs/pull/373
-- Ember Issue: (leave this empty)
+---
+Start Date: 2018-09-10
+RFC PR: https://github.com/emberjs/rfcs/pull/373
+Ember Issue: (leave this empty)
+
+---
 
 # Element Modifier Manager
 

--- a/text/0373-Element-Modifier-Managers.md
+++ b/text/0373-Element-Modifier-Managers.md
@@ -1,7 +1,6 @@
 ---
 Start Date: 2018-09-10
 RFC PR: https://github.com/emberjs/rfcs/pull/373
-Ember Issue: (leave this empty)
 
 ---
 

--- a/text/0375-deprecate-computed-property-modifier.md
+++ b/text/0375-deprecate-computed-property-modifier.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-09-13
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/375
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/15
+---
+Start Date: 2019-09-13
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/375
+Tracking: https://github.com/emberjs/rfc-tracking/issues/15
+
+---
 
 # Summary
 

--- a/text/0386-remove-jquery.md
+++ b/text/0386-remove-jquery.md
@@ -1,7 +1,10 @@
-- Start Date: 2018-10-07
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/386
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/3
+---
+Start Date: 2018-10-07
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/386
+Tracking: https://github.com/emberjs/rfc-tracking/issues/3
+
+---
 
 # Remove jQuery by default
 

--- a/text/0389-dynamic-tag-names.md
+++ b/text/0389-dynamic-tag-names.md
@@ -1,7 +1,10 @@
-- Start Date: 2018-10-14
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/389
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/42
+---
+Start Date: 2018-10-14
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/389
+Tracking: https://github.com/emberjs/rfc-tracking/issues/42
+
+---
 
 # Dynamic tag names in glimmer templates.
 

--- a/text/0391-router-helpers.md
+++ b/text/0391-router-helpers.md
@@ -1,7 +1,10 @@
-- Start Date: 2018-10-22
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/391
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/14
+---
+Start Date: 2018-10-22
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/391
+Tracking: https://github.com/emberjs/rfc-tracking/issues/14
+
+---
 
 # Router Helpers
 

--- a/text/0392-deprecate-component-manager-string-lookup.md
+++ b/text/0392-deprecate-component-manager-string-lookup.md
@@ -1,6 +1,9 @@
-- Start Date: 2018-10-23
-- RFC PR: https://github.com/emberjs/rfcs/pull/392
-- Ember Issue: (leave this empty)
+---
+Start Date: 2018-10-23
+RFC PR: https://github.com/emberjs/rfcs/pull/392
+Ember Issue: (leave this empty)
+
+---
 
 # Summary
 

--- a/text/0392-deprecate-component-manager-string-lookup.md
+++ b/text/0392-deprecate-component-manager-string-lookup.md
@@ -1,7 +1,6 @@
 ---
 Start Date: 2018-10-23
 RFC PR: https://github.com/emberjs/rfcs/pull/392
-Ember Issue: (leave this empty)
 
 ---
 

--- a/text/0395-ember-data-packages.md
+++ b/text/0395-ember-data-packages.md
@@ -1,7 +1,10 @@
-- Start Date: 2018-10-31
-- Relevant Team(s): Ember Data
-- RFC PR: https://github.com/emberjs/rfcs/pull/395
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/11
+---
+Start Date: 2018-10-31
+Relevant Team(s): Ember Data
+RFC PR: https://github.com/emberjs/rfcs/pull/395
+Tracking: https://github.com/emberjs/rfc-tracking/issues/11
+
+---
 
 # Ember Data Packages
 

--- a/text/0398-RouteInfo-Metadata.md
+++ b/text/0398-RouteInfo-Metadata.md
@@ -1,7 +1,10 @@
-- Start Date: 2018-11-02
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/398
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/10
+---
+Start Date: 2018-11-02
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/398
+Tracking: https://github.com/emberjs/rfc-tracking/issues/10
+
+---
 
 # RouteInfo MetaData
 

--- a/text/0403-ember-data-identifiers.md
+++ b/text/0403-ember-data-identifiers.md
@@ -1,7 +1,10 @@
-- Start Date: 2018-11-25
-- Relevant Team(s): Ember Data
-- RFC PR: https://github.com/emberjs/rfcs/pull/403
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/31
+---
+Start Date: 2018-11-25
+Relevant Team(s): Ember Data
+RFC PR: https://github.com/emberjs/rfcs/pull/403
+Tracking: https://github.com/emberjs/rfc-tracking/issues/31
+
+---
 
 # Ember Data | Identifiers 
 

--- a/text/0408-decorators.md
+++ b/text/0408-decorators.md
@@ -1,7 +1,10 @@
-- Start Date: 2018-10-20
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/408
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/7
+---
+Start Date: 2018-10-20
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/408
+Tracking: https://github.com/emberjs/rfc-tracking/issues/7
+
+---
 
 # Decorators
 

--- a/text/0410-tracked-properties.md
+++ b/text/0410-tracked-properties.md
@@ -1,8 +1,11 @@
-- Start Date: 2018-12-05
-- RFC PR: https://github.com/emberjs/rfcs/pull/410
-- Relevant Team(s): Ember.js
-- Authors: Tom Dale, Chris Garrett, Chad Hietala, Yehuda Katz
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/4
+---
+Start Date: 2018-12-05
+RFC PR: https://github.com/emberjs/rfcs/pull/410
+Relevant Team(s): Ember.js
+Authors: Tom Dale, Chris Garrett, Chad Hietala, Yehuda Katz
+Tracking: https://github.com/emberjs/rfc-tracking/issues/4
+
+---
 
 # Tracked Properties
 

--- a/text/0415-render-element-modifiers.md
+++ b/text/0415-render-element-modifiers.md
@@ -1,7 +1,10 @@
-- Start Date: 2018-12-13
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/415
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/8
+---
+Start Date: 2018-12-13
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/415
+Tracking: https://github.com/emberjs/rfc-tracking/issues/8
+
+---
 
 # Render Element Modifiers
 

--- a/text/0416-glimmer-components.md
+++ b/text/0416-glimmer-components.md
@@ -1,7 +1,10 @@
-- Start Date: 2018-12-13
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/416
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/2
+---
+Start Date: 2018-12-13
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/416
+Tracking: https://github.com/emberjs/rfc-tracking/issues/2
+
+---
 
 # Glimmer Components
 

--- a/text/0418-deprecate-route-render-methods.md
+++ b/text/0418-deprecate-route-render-methods.md
@@ -1,7 +1,10 @@
-- Start Date: 2018-19-12
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/418
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/30
+---
+Start Date: 2018-19-12
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/418
+Tracking: https://github.com/emberjs/rfc-tracking/issues/30
+
+---
 
 # Deprecate Route render APIs
 

--- a/text/0421-deprecate-application-controller-props.md
+++ b/text/0421-deprecate-application-controller-props.md
@@ -1,7 +1,10 @@
-- Start Date: 2018-19-12
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/421
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/5
+---
+Start Date: 2018-19-12
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/421
+Tracking: https://github.com/emberjs/rfc-tracking/issues/5
+
+---
 
 # Deprecate Application Controller Router Properties
 

--- a/text/0425-website-redesign.md
+++ b/text/0425-website-redesign.md
@@ -1,7 +1,10 @@
-- Start Date: 2018-12-21
-- Relevant Team(s): Learning, Steering
-- RFC PR: https://github.com/emberjs/rfcs/pull/425
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/35
+---
+Start Date: 2018-12-21
+Relevant Team(s): Learning, Steering
+RFC PR: https://github.com/emberjs/rfcs/pull/425
+Tracking: https://github.com/emberjs/rfc-tracking/issues/35
+
+---
 
 # Website Redesign
 

--- a/text/0431-guides-restructure.md
+++ b/text/0431-guides-restructure.md
@@ -1,7 +1,10 @@
-- Start Date: 2018-01-13
-- Relevant Team(s): Learning
-- RFC PR: https://github.com/emberjs/rfcs/pull/431
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/29
+---
+Start Date: 2018-01-13
+Relevant Team(s): Learning
+RFC PR: https://github.com/emberjs/rfcs/pull/431
+Tracking: https://github.com/emberjs/rfc-tracking/issues/29
+
+---
 
 # Restructuring the Guides Table of Contents
 

--- a/text/0432-contextual-helpers.md
+++ b/text/0432-contextual-helpers.md
@@ -1,7 +1,10 @@
-- Start Date: 2018-12-17
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/432
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/6
+---
+Start Date: 2018-12-17
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/432
+Tracking: https://github.com/emberjs/rfc-tracking/issues/6
+
+---
 
 # Contextual Helpers and Modifiers (a.k.a. "first-class helpers/modifiers")
 

--- a/text/0435-modifier-splattributes.md
+++ b/text/0435-modifier-splattributes.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-01-18
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/435
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/9
+---
+Start Date: 2019-01-18
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/435
+Tracking: https://github.com/emberjs/rfc-tracking/issues/9
+
+---
 
 # Forwarding Element Modifiers with "Splattributes"
 

--- a/text/0440-decorator-support.md
+++ b/text/0440-decorator-support.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-02-06
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/440
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/41
+---
+Start Date: 2019-02-06
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/440
+Tracking: https://github.com/emberjs/rfc-tracking/issues/41
+
+---
 
 # Decorator Support
 

--- a/text/0445-deprecate-with.md
+++ b/text/0445-deprecate-with.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-02-13
-- Relevant Teams: Ember.js, Learning
-- RFC PR: https://github.com/emberjs/rfcs/pull/445
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/40
+---
+Start Date: 2019-02-13
+Relevant Teams: Ember.js, Learning
+RFC PR: https://github.com/emberjs/rfcs/pull/445
+Tracking: https://github.com/emberjs/rfc-tracking/issues/40
+
+---
 
 # Deprecate `{{with}}`
 

--- a/text/0446-contribution-guides.md
+++ b/text/0446-contribution-guides.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-02-14
-- Relevant Team(s): Learning
-- RFC PR: https://github.com/emberjs/rfcs/pull/446
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/39
+---
+Start Date: 2019-02-14
+Relevant Team(s): Learning
+RFC PR: https://github.com/emberjs/rfcs/pull/446
+Tracking: https://github.com/emberjs/rfc-tracking/issues/39
+
+---
 
 # Contribution Guides
 

--- a/text/0449-deprecate-partials.md
+++ b/text/0449-deprecate-partials.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-02-17
-- Relevant Teams: Ember.js, Learning
-- RFC PR: https://github.com/emberjs/rfcs/pull/449
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/38
+---
+Start Date: 2019-02-17
+Relevant Teams: Ember.js, Learning
+RFC PR: https://github.com/emberjs/rfcs/pull/449
+Tracking: https://github.com/emberjs/rfc-tracking/issues/38
+
+---
 
 # Deprecate `{{partial}}`
 

--- a/text/0451-injection-parameter-normalization.md
+++ b/text/0451-injection-parameter-normalization.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-02-19
-- Relevant Team(s): Ember.js, Ember Data, Learning
-- RFC PR: https://github.com/emberjs/rfcs/pull/451
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/34
+---
+Start Date: 2019-02-19
+Relevant Team(s): Ember.js, Ember Data, Learning
+RFC PR: https://github.com/emberjs/rfcs/pull/451
+Tracking: https://github.com/emberjs/rfc-tracking/issues/34
+
+---
 
 # Injection Parameter Normalization
 

--- a/text/0452-ember-data-medium-term-plan.md
+++ b/text/0452-ember-data-medium-term-plan.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-02-20
-- Relevant Team(s): Ember Data
-- RFC PR: [452](https://github.com/emberjs/rfcs/pull/452)
-- Tracking: [Issue](https://github.com/emberjs/rfc-tracking/issues/50)
+---
+Start Date: 2019-02-20
+Relevant Team(s): Ember Data
+RFC PR: 452
+Tracking: Issue
+
+---
 
 # **Summary**
 

--- a/text/0452-ember-data-medium-term-plan.md
+++ b/text/0452-ember-data-medium-term-plan.md
@@ -1,8 +1,8 @@
 ---
 Start Date: 2019-02-20
 Relevant Team(s): Ember Data
-RFC PR: 452
-Tracking: Issue
+RFC PR: https://github.com/emberjs/rfcs/pull/452
+Tracking: https://github.com/emberjs/rfc-tracking/issues/50
 
 ---
 

--- a/text/0457-nested-lookups.md
+++ b/text/0457-nested-lookups.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-03-05
-- Relevant Team(s): Ember.js
-- RFC PR: [#457](https://github.com/emberjs/rfcs/pull/457)
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/37
+---
+Start Date: 2019-03-05
+Relevant Team(s): Ember.js
+RFC PR: #457
+Tracking: https://github.com/emberjs/rfc-tracking/issues/37
+
+---
 
 # Nested Invocations in Angle Bracket Syntax
 

--- a/text/0457-nested-lookups.md
+++ b/text/0457-nested-lookups.md
@@ -1,7 +1,7 @@
 ---
 Start Date: 2019-03-05
 Relevant Team(s): Ember.js
-RFC PR: #457
+RFC PR: https://github.com/emberjs/rfcs/pull/457
 Tracking: https://github.com/emberjs/rfc-tracking/issues/37
 
 ---

--- a/text/0459-angle-bracket-built-in-components.md
+++ b/text/0459-angle-bracket-built-in-components.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-03-05
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/459
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/36
+---
+Start Date: 2019-03-05
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/459
+Tracking: https://github.com/emberjs/rfc-tracking/issues/36
+
+---
 
 # Angle Bracket Invocations For Built-in Components
 

--- a/text/0460-yieldable-named-blocks.md
+++ b/text/0460-yieldable-named-blocks.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-03-06
-- Relevant Team(s): Ember.js
-- RFC PR: [#460](https://github.com/emberjs/rfcs/pull/460)
-- Tracking: (leave this empty)
+---
+Start Date: 2019-03-06
+Relevant Team(s): Ember.js
+RFC PR: #460
+Tracking: (leave this empty)
+
+---
 
 # Yieldable Named Blocks
 

--- a/text/0460-yieldable-named-blocks.md
+++ b/text/0460-yieldable-named-blocks.md
@@ -1,8 +1,7 @@
 ---
 Start Date: 2019-03-06
 Relevant Team(s): Ember.js
-RFC PR: #460
-Tracking: (leave this empty)
+RFC PR: https://github.com/emberjs/rfcs/pull/460
 
 ---
 

--- a/text/0461-ember-data-singleton-record-data.md
+++ b/text/0461-ember-data-singleton-record-data.md
@@ -1,6 +1,9 @@
-- Start Date: 2019-03-06
-- RFC PR: 461
-- [RFC Tracking Issue #51](https://github.com/emberjs/rfc-tracking/issues/51)
+---
+Start Date: 2019-03-06
+RFC PR: 461
+Tracking: https://github.com/emberjs/rfc-tracking/issues/51
+
+---
 
 # Singleton Record Data
 

--- a/text/0461-ember-data-singleton-record-data.md
+++ b/text/0461-ember-data-singleton-record-data.md
@@ -1,6 +1,6 @@
 ---
 Start Date: 2019-03-06
-RFC PR: 461
+RFC PR: https://github.com/emberjs/rfcs/pull/461
 Tracking: https://github.com/emberjs/rfc-tracking/issues/51
 
 ---

--- a/text/0463-record-data-state.md
+++ b/text/0463-record-data-state.md
@@ -1,8 +1,10 @@
-- Start Date: 2019-03-13
-- Relevant Team(s): data
-- RFC PR: https://github.com/emberjs/rfcs/pull/463
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/47
-    
+---
+Start Date: 2019-03-13
+Relevant Team(s): data
+RFC PR: https://github.com/emberjs/rfcs/pull/463
+Tracking: https://github.com/emberjs/rfc-tracking/issues/47
+
+---
 # Record State on Record Data RFC
   
 

--- a/text/0463-record-data-state.md
+++ b/text/0463-record-data-state.md
@@ -5,6 +5,7 @@ RFC PR: https://github.com/emberjs/rfcs/pull/463
 Tracking: https://github.com/emberjs/rfc-tracking/issues/47
 
 ---
+
 # Record State on Record Data RFC
   
 

--- a/text/0465-record-data-errors.md
+++ b/text/0465-record-data-errors.md
@@ -1,8 +1,10 @@
-- Start Date: 2019-03-13
-- Relevant Team(s): data
-- RFC PR: https://github.com/emberjs/rfcs/pull/465  
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/46 
-    
+---
+Start Date: 2019-03-13
+Relevant Team(s): data
+RFC PR: https://github.com/emberjs/rfcs/pull/465
+Tracking: https://github.com/emberjs/rfc-tracking/issues/46
+
+---
 # Record Data Errors RFC
 
 ## Summary

--- a/text/0465-record-data-errors.md
+++ b/text/0465-record-data-errors.md
@@ -5,6 +5,7 @@ RFC PR: https://github.com/emberjs/rfcs/pull/465
 Tracking: https://github.com/emberjs/rfc-tracking/issues/46
 
 ---
+
 # Record Data Errors RFC
 
 ## Summary

--- a/text/0466-request-state-service.md
+++ b/text/0466-request-state-service.md
@@ -1,8 +1,10 @@
-- Start Date: 2019-03-09
-- Relevant Team(s): data
-- RFC PR: [PR](https://github.com/emberjs/rfcs/pull/466)
-- Tracking: [Tracking](https://github.com/emberjs/rfc-tracking/issues/52)
-    
+---
+Start Date: 2019-03-09
+Relevant Team(s): data
+RFC PR: PR
+Tracking: Tracking
+
+---
 # Request State Service
     
 

--- a/text/0466-request-state-service.md
+++ b/text/0466-request-state-service.md
@@ -1,10 +1,11 @@
 ---
 Start Date: 2019-03-09
 Relevant Team(s): data
-RFC PR: PR
-Tracking: Tracking
+RFC PR: https://github.com/emberjs/rfcs/pull/466
+Tracking: https://github.com/emberjs/rfc-tracking/issues/52
 
 ---
+
 # Request State Service
     
 

--- a/text/0468-classic-decorator.md
+++ b/text/0468-classic-decorator.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-03-14
-- Relevant Team(s): Ember.js, Ember Data, Learning
-- RFC PR: https://github.com/emberjs/rfcs/pull/468
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/55
+---
+Start Date: 2019-03-14
+Relevant Team(s): Ember.js, Ember Data, Learning
+RFC PR: https://github.com/emberjs/rfcs/pull/468
+Tracking: https://github.com/emberjs/rfc-tracking/issues/55
+
+---
 
 # `@classic` Decorator
 

--- a/text/0470-fn-helper.md
+++ b/text/0470-fn-helper.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-03-20
-- Relevant Team(s): Ember.js, Learning
-- RFC PR: https://github.com/emberjs/rfcs/pull/470
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/33
+---
+Start Date: 2019-03-20
+Relevant Team(s): Ember.js, Learning
+RFC PR: https://github.com/emberjs/rfcs/pull/470
+Tracking: https://github.com/emberjs/rfc-tracking/issues/33
+
+---
 
 # `{{fn}}` Helper
 

--- a/text/0471-on-modifier.md
+++ b/text/0471-on-modifier.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-03-21
-- Relevant Team(s): Ember.js, Learning
-- RFC PR: https://github.com/emberjs/rfcs/pull/471
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/32
+---
+Start Date: 2019-03-21
+Relevant Team(s): Ember.js, Learning
+RFC PR: https://github.com/emberjs/rfcs/pull/471
+Tracking: https://github.com/emberjs/rfc-tracking/issues/32
+
+---
 
 # `{{on}}` Modifier
 

--- a/text/0477-blueprints-update.md
+++ b/text/0477-blueprints-update.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-04-17
-- Relevant Team(s): Ember CLI
-- RFC PR: https://github.com/emberjs/rfcs/pull/477
-- Tracking: (leave this empty)
+---
+Start Date: 2019-04-17
+Relevant Team(s): Ember CLI
+RFC PR: https://github.com/emberjs/rfcs/pull/477
+Tracking: (leave this empty)
+
+---
 
 # Syncing Blueprints
 

--- a/text/0477-blueprints-update.md
+++ b/text/0477-blueprints-update.md
@@ -2,7 +2,6 @@
 Start Date: 2019-04-17
 Relevant Team(s): Ember CLI
 RFC PR: https://github.com/emberjs/rfcs/pull/477
-Tracking: (leave this empty)
 
 ---
 

--- a/text/0478-tracked-properties-updates.md
+++ b/text/0478-tracked-properties-updates.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-04-12
-- Relevant Team(s): Ember.js, Learning
-- RFC PR: https://github.com/emberjs/rfcs/pull/478
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/45
+---
+Start Date: 2019-04-12
+Relevant Team(s): Ember.js, Learning
+RFC PR: https://github.com/emberjs/rfcs/pull/478
+Tracking: https://github.com/emberjs/rfc-tracking/issues/45
+
+---
 
 # Tracked Properties Updates
 

--- a/text/0481-component-templates-co-location.md
+++ b/text/0481-component-templates-co-location.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-04-12
-- Relevant Team(s): Ember.js, Ember CLI
-- RFC PR: https://github.com/emberjs/rfcs/pull/481
-- Tracking: (leave this empty)
+---
+Start Date: 2019-04-12
+Relevant Team(s): Ember.js, Ember CLI
+RFC PR: https://github.com/emberjs/rfcs/pull/481
+Tracking: (leave this empty)
+
+---
 
 # Component Templates Co-location
 

--- a/text/0481-component-templates-co-location.md
+++ b/text/0481-component-templates-co-location.md
@@ -2,7 +2,6 @@
 Start Date: 2019-04-12
 Relevant Team(s): Ember.js, Ember CLI
 RFC PR: https://github.com/emberjs/rfcs/pull/481
-Tracking: (leave this empty)
 
 ---
 

--- a/text/0486-deprecate-mouseenter.md
+++ b/text/0486-deprecate-mouseenter.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-04-28
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/486
-- Tracking: https://github.com/emberjs/rfc-tracking/issues/54
+---
+Start Date: 2019-04-28
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/486
+Tracking: https://github.com/emberjs/rfc-tracking/issues/54
+
+---
 
 # Deprecate support for mouseEnter/Leave/Move Ember events
 

--- a/text/0487-custom-model-classes.md
+++ b/text/0487-custom-model-classes.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-05-09
-- Relevant Team(s): data 
-- RFC PR: [PR](https://github.com/emberjs/rfcs/pull/487)
-- Tracking: [Tracking](https://github.com/emberjs/rfc-tracking/issues/53)
+---
+Start Date: 2019-05-09
+Relevant Team(s): data
+RFC PR: PR
+Tracking: Tracking
+
+---
 
 # Custom Model Class RFC
 

--- a/text/0487-custom-model-classes.md
+++ b/text/0487-custom-model-classes.md
@@ -1,8 +1,8 @@
 ---
 Start Date: 2019-05-09
 Relevant Team(s): data
-RFC PR: PR
-Tracking: Tracking
+RFC PR: https://github.com/emberjs/rfcs/pull/487
+Tracking: https://github.com/emberjs/rfc-tracking/issues/53
 
 ---
 

--- a/text/0491-deprecate-disconnect-outlet.md
+++ b/text/0491-deprecate-disconnect-outlet.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-05-20
-- Relevant Team(s): Ember.js, Learning
-- RFC PR: https://github.com/emberjs/rfcs/pull/491
-- Tracking: (leave this empty)
+---
+Start Date: 2019-05-20
+Relevant Team(s): Ember.js, Learning
+RFC PR: https://github.com/emberjs/rfcs/pull/491
+Tracking: (leave this empty)
+
+---
 
 # Deprecate `disconnectOutlet`
 

--- a/text/0491-deprecate-disconnect-outlet.md
+++ b/text/0491-deprecate-disconnect-outlet.md
@@ -2,7 +2,6 @@
 Start Date: 2019-05-20
 Relevant Team(s): Ember.js, Learning
 RFC PR: https://github.com/emberjs/rfcs/pull/491
-Tracking: (leave this empty)
 
 ---
 

--- a/text/0494-async-observers.md
+++ b/text/0494-async-observers.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-05-30
-- Relevant Team(s): Ember.js, Learning
-- RFC PR: https://github.com/emberjs/rfcs/pull/494
-- Tracking: (leave this empty)
+---
+Start Date: 2019-05-30
+Relevant Team(s): Ember.js, Learning
+RFC PR: https://github.com/emberjs/rfcs/pull/494
+Tracking: (leave this empty)
+
+---
 
 # Async Observers
 

--- a/text/0494-async-observers.md
+++ b/text/0494-async-observers.md
@@ -2,7 +2,6 @@
 Start Date: 2019-05-30
 Relevant Team(s): Ember.js, Learning
 RFC PR: https://github.com/emberjs/rfcs/pull/494
-Tracking: (leave this empty)
 
 ---
 

--- a/text/0496-handlebars-strict-mode.md
+++ b/text/0496-handlebars-strict-mode.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-02-14
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/496
-- Tracking: (leave this empty)
+---
+Start Date: 2019-02-14
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/496
+Tracking: (leave this empty)
+
+---
 
 # Handlebars Strict Mode
 

--- a/text/0496-handlebars-strict-mode.md
+++ b/text/0496-handlebars-strict-mode.md
@@ -2,7 +2,6 @@
 Start Date: 2019-02-14
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/496
-Tracking: (leave this empty)
 
 ---
 

--- a/text/0507-embroider-v2-package-format.md
+++ b/text/0507-embroider-v2-package-format.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-06-21
-- Relevant Team(s): Ember CLI, Ember.js, Learning
-- RFC PR: https://github.com/emberjs/rfcs/pull/507
-- Tracking:
+---
+Start Date: 2019-06-21
+Relevant Team(s): Ember CLI, Ember.js, Learning
+RFC PR: https://github.com/emberjs/rfcs/pull/507
+Tracking: 
+
+---
 
 # v2 Addon Format (Embroider Compatibility)
 

--- a/text/0507-embroider-v2-package-format.md
+++ b/text/0507-embroider-v2-package-format.md
@@ -2,7 +2,6 @@
 Start Date: 2019-06-21
 Relevant Team(s): Ember CLI, Ember.js, Learning
 RFC PR: https://github.com/emberjs/rfcs/pull/507
-Tracking: 
 
 ---
 

--- a/text/0519-2019-2020-roadmap.md
+++ b/text/0519-2019-2020-roadmap.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-07-29, heavily revised 2020-02-28
-- Relevant Team(s): All teams
-- RFC PR: [https://github.com/emberjs/rfcs/pull/519](https://github.com/emberjs/rfcs/pull/519)
-- Tracking:
+---
+Start Date: 2019-07-29, heavily revised 2020-02-28
+Relevant Team(s): All teams
+RFC PR: https://github.com/emberjs/rfcs/pull/519
+Tracking: 
+
+---
 
 # Ember 2020 Roadmap
 

--- a/text/0519-2019-2020-roadmap.md
+++ b/text/0519-2019-2020-roadmap.md
@@ -1,8 +1,8 @@
 ---
-Start Date: 2019-07-29, heavily revised 2020-02-28
+Start Date: 2019-07-29
+Heavily Revised: 2020-02-28
 Relevant Team(s): All teams
 RFC PR: https://github.com/emberjs/rfcs/pull/519
-Tracking: 
 
 ---
 

--- a/text/0521-find-by-identifier.md
+++ b/text/0521-find-by-identifier.md
@@ -1,7 +1,10 @@
-- Start Date: (fill me in with today's date, 2019-08-29)
-- Relevant Team(s): EmberData
-- RFC PR: https://github.com/emberjs/rfcs/pull/521
-- Tracking: (leave this empty)
+---
+Start Date: (fill me in with today's date, 2019-08-29)
+Relevant Team(s): EmberData
+RFC PR: https://github.com/emberjs/rfcs/pull/521
+Tracking: (leave this empty)
+
+---
 
 # [DATA] findRecord/peekRecord via Identifier
 

--- a/text/0521-find-by-identifier.md
+++ b/text/0521-find-by-identifier.md
@@ -1,8 +1,7 @@
 ---
-Start Date: (fill me in with today's date, 2019-08-29)
+Start Date: 2019-08-29
 Relevant Team(s): EmberData
 RFC PR: https://github.com/emberjs/rfcs/pull/521
-Tracking: (leave this empty)
 
 ---
 

--- a/text/0522-default-serializers-and-adapters.md
+++ b/text/0522-default-serializers-and-adapters.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-07-27
-- Relevant Team(s): Ember Data
-- RFC PR: https://github.com/emberjs/rfcs/pull/522
-- Tracking:
+---
+Start Date: 2019-07-27
+Relevant Team(s): Ember Data
+RFC PR: https://github.com/emberjs/rfcs/pull/522
+Tracking: 
+
+---
 
 # Deprecate default Adapter and Serializer fallbacks
 

--- a/text/0522-default-serializers-and-adapters.md
+++ b/text/0522-default-serializers-and-adapters.md
@@ -2,7 +2,6 @@
 Start Date: 2019-07-27
 Relevant Team(s): Ember Data
 RFC PR: https://github.com/emberjs/rfcs/pull/522
-Tracking: 
 
 ---
 

--- a/text/0523-model-argument-for-route-templates.md
+++ b/text/0523-model-argument-for-route-templates.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-08-05
-- Relevant Team(s): Ember.js, Learning
-- RFC PR: https://github.com/emberjs/rfcs/pull/523
-- Tracking: (leave this empty)
+---
+Start Date: 2019-08-05
+Relevant Team(s): Ember.js, Learning
+RFC PR: https://github.com/emberjs/rfcs/pull/523
+Tracking: (leave this empty)
+
+---
 
 # Provide `@model` named argument to route templates
 

--- a/text/0523-model-argument-for-route-templates.md
+++ b/text/0523-model-argument-for-route-templates.md
@@ -2,7 +2,6 @@
 Start Date: 2019-08-05
 Relevant Team(s): Ember.js, Learning
 RFC PR: https://github.com/emberjs/rfcs/pull/523
-Tracking: (leave this empty)
 
 ---
 

--- a/text/0554-deprecate-getwithdefault.md
+++ b/text/0554-deprecate-getwithdefault.md
@@ -1,7 +1,10 @@
-- Start Date: 2019-11-08
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/554
-- Tracking: (leave this empty)
+---
+Start Date: 2019-11-08
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/554
+Tracking: (leave this empty)
+
+---
 
 # Deprecate getWithDefault
 

--- a/text/0554-deprecate-getwithdefault.md
+++ b/text/0554-deprecate-getwithdefault.md
@@ -2,7 +2,6 @@
 Start Date: 2019-11-08
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/554
-Tracking: (leave this empty)
 
 ---
 

--- a/text/0558-edition-detection.md
+++ b/text/0558-edition-detection.md
@@ -1,7 +1,10 @@
-- Start Date: (2019-11-20)
-- Relevant Team(s): (Ember.js, Ember CLI, Ember Data)
-- RFC PR: https://github.com/emberjs/rfcs/pull/558
-- Tracking: (leave this empty)
+---
+Start Date: (2019-11-20)
+Relevant Team(s): (Ember.js, Ember CLI, Ember Data)
+RFC PR: https://github.com/emberjs/rfcs/pull/558
+Tracking: (leave this empty)
+
+---
 
 # Edition detection
 

--- a/text/0558-edition-detection.md
+++ b/text/0558-edition-detection.md
@@ -1,8 +1,7 @@
 ---
-Start Date: (2019-11-20)
-Relevant Team(s): (Ember.js, Ember CLI, Ember Data)
+Start Date: 2019-11-20
+Relevant Team(s): Ember.js, Ember CLI, Ember Data
 RFC PR: https://github.com/emberjs/rfcs/pull/558
-Tracking: (leave this empty)
 
 ---
 

--- a/text/0580-destroyables.md
+++ b/text/0580-destroyables.md
@@ -1,7 +1,10 @@
-- Start Date: 2020-01-10
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/580
-- Tracking: (leave this empty)
+---
+Start Date: 2020-01-10
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/580
+Tracking: (leave this empty)
+
+---
 
 # Destroyables
 

--- a/text/0580-destroyables.md
+++ b/text/0580-destroyables.md
@@ -2,7 +2,6 @@
 Start Date: 2020-01-10
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/580
-Tracking: (leave this empty)
 
 ---
 

--- a/text/0581-new-test-waiters.md
+++ b/text/0581-new-test-waiters.md
@@ -1,6 +1,9 @@
-- Start Date: 2020-01-14
-- RFC PR: (leave this empty)
-- Ember Issue: (leave this empty)
+---
+Start Date: 2020-01-14
+RFC PR: (leave this empty)
+Ember Issue: (leave this empty)
+
+---
 
 # Summary
 

--- a/text/0581-new-test-waiters.md
+++ b/text/0581-new-test-waiters.md
@@ -1,7 +1,6 @@
 ---
 Start Date: 2020-01-14
-RFC PR: (leave this empty)
-Ember Issue: (leave this empty)
+RFC PR: https://github.com/emberjs/rfcs/pull/581
 
 ---
 

--- a/text/0585-improved-ember-registry-apis.md
+++ b/text/0585-improved-ember-registry-apis.md
@@ -1,7 +1,10 @@
-- Start Date: 2020-01-27
-- Relevant Team(s): Ember.js, Learning
-- RFC PR: [#0585](https://github.com/emberjs/rfcs/pull/585)
-- Tracking: (leave this empty)
+---
+Start Date: 2020-01-27
+Relevant Team(s): Ember.js, Learning
+RFC PR: #0585
+Tracking: (leave this empty)
+
+---
 
 # Improved Ember Registry APIs
 

--- a/text/0585-improved-ember-registry-apis.md
+++ b/text/0585-improved-ember-registry-apis.md
@@ -1,8 +1,7 @@
 ---
 Start Date: 2020-01-27
 Relevant Team(s): Ember.js, Learning
-RFC PR: #0585
-Tracking: (leave this empty)
+RFC PR: https://github.com/emberjs/rfcs/pull/585
 
 ---
 

--- a/text/0615-autotracking-memoization.md
+++ b/text/0615-autotracking-memoization.md
@@ -1,7 +1,10 @@
-- Start Date: 2020-04-17
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/615
-- Tracking: (leave this empty)
+---
+Start Date: 2020-04-17
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/615
+Tracking: (leave this empty)
+
+---
 
 # Autotracking Memoization
 

--- a/text/0615-autotracking-memoization.md
+++ b/text/0615-autotracking-memoization.md
@@ -2,7 +2,6 @@
 Start Date: 2020-04-17
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/615
-Tracking: (leave this empty)
 
 ---
 

--- a/text/0617-rfc-stages.md
+++ b/text/0617-rfc-stages.md
@@ -1,7 +1,10 @@
-- Start Date: 2020-04-22
-- Relevant Team(s): (fill this in with the team(s) to which this RFC applies)
-- RFC PR: https://github.com/emberjs/rfcs/pull/617
-- Tracking: (leave this empty)
+---
+Start Date: 2020-04-22
+Relevant Team(s): (fill this in with the team(s) to which this RFC applies)
+RFC PR: https://github.com/emberjs/rfcs/pull/617
+Tracking: (leave this empty)
+
+---
 
 # RFC Stages
 

--- a/text/0617-rfc-stages.md
+++ b/text/0617-rfc-stages.md
@@ -1,8 +1,7 @@
 ---
 Start Date: 2020-04-22
-Relevant Team(s): (fill this in with the team(s) to which this RFC applies)
+Relevant Team(s): All teams
 RFC PR: https://github.com/emberjs/rfcs/pull/617
-Tracking: (leave this empty)
 
 ---
 

--- a/text/0625-helper-managers.md
+++ b/text/0625-helper-managers.md
@@ -1,7 +1,10 @@
-- Start Date: 2020-04-28
-- Relevant Team(s): Ember.js
-- RFC PR: (after opening the RFC PR, update this with a link to it and update the file name)
-- Tracking: (leave this empty)
+---
+Start Date: 2020-04-28
+Relevant Team(s): Ember.js
+RFC PR: (after opening the RFC PR, update this with a link to it and update the file name)
+Tracking: (leave this empty)
+
+---
 
 # Helper Managers
 

--- a/text/0625-helper-managers.md
+++ b/text/0625-helper-managers.md
@@ -1,8 +1,7 @@
 ---
 Start Date: 2020-04-28
 Relevant Team(s): Ember.js
-RFC PR: (after opening the RFC PR, update this with a link to it and update the file name)
-Tracking: (leave this empty)
+RFC PR: https://github.com/emberjs/rfcs/pull/625
 
 ---
 

--- a/text/0626-invoke-helper.md
+++ b/text/0626-invoke-helper.md
@@ -1,7 +1,10 @@
-- Start Date: 2020-04-30
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/626
-- Tracking: (leave this empty)
+---
+Start Date: 2020-04-30
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/626
+Tracking: (leave this empty)
+
+---
 
 # JavaScript Helper Invocation API
 

--- a/text/0626-invoke-helper.md
+++ b/text/0626-invoke-helper.md
@@ -2,7 +2,6 @@
 Start Date: 2020-04-30
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/626
-Tracking: (leave this empty)
 
 ---
 

--- a/text/0628-prettier.md
+++ b/text/0628-prettier.md
@@ -1,7 +1,10 @@
-- Start Date: 2020-05-18
-- Relevant Team(s): Ember CLI
-- RFC PR: https://github.com/emberjs/rfcs/pull/628
-- Tracking: (leave this empty)
+---
+Start Date: 2020-05-18
+Relevant Team(s): Ember CLI
+RFC PR: https://github.com/emberjs/rfcs/pull/628
+Tracking: (leave this empty)
+
+---
 
 # Add Prettier
 

--- a/text/0628-prettier.md
+++ b/text/0628-prettier.md
@@ -2,7 +2,6 @@
 Start Date: 2020-05-18
 Relevant Team(s): Ember CLI
 RFC PR: https://github.com/emberjs/rfcs/pull/628
-Tracking: (leave this empty)
 
 ---
 

--- a/text/0631-refresh-method-for-router-service.md
+++ b/text/0631-refresh-method-for-router-service.md
@@ -1,7 +1,10 @@
-- Start Date: 2020-05-23
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/631
-- Tracking: (leave this empty)
+---
+Start Date: 2020-05-23
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/631
+Tracking: (leave this empty)
+
+---
 
 # RouterService#refresh
 

--- a/text/0631-refresh-method-for-router-service.md
+++ b/text/0631-refresh-method-for-router-service.md
@@ -2,7 +2,6 @@
 Start Date: 2020-05-23
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/631
-Tracking: (leave this empty)
 
 ---
 

--- a/text/0635-ember-new-lang.md
+++ b/text/0635-ember-new-lang.md
@@ -1,8 +1,11 @@
-- Start Date: 2020-05-29
-- Relevant Team(s): CLI, Learning
-- RFC PR: https://github.com/emberjs/rfcs/pull/635
-- Tracking: (leave this empty)
-- Authors: Joseph Sumner, Ava Wroten, Jamie White, Melanie Sumner
+---
+Start Date: 2020-05-29
+Relevant Team(s): CLI, Learning
+RFC PR: https://github.com/emberjs/rfcs/pull/635
+Tracking: (leave this empty)
+Authors: Joseph Sumner, Ava Wroten, Jamie White, Melanie Sumner
+
+---
 
 # Ember New Lang
 

--- a/text/0635-ember-new-lang.md
+++ b/text/0635-ember-new-lang.md
@@ -2,7 +2,6 @@
 Start Date: 2020-05-29
 Relevant Team(s): CLI, Learning
 RFC PR: https://github.com/emberjs/rfcs/pull/635
-Tracking: (leave this empty)
 Authors: Joseph Sumner, Ava Wroten, Jamie White, Melanie Sumner
 
 ---

--- a/text/0637-customizable-test-setups.md
+++ b/text/0637-customizable-test-setups.md
@@ -1,7 +1,10 @@
-- Start Date: 2020-06-01
-- Relevant Team(s): Ember-CLI
-- RFC PR: https://github.com/emberjs/rfcs/pull/637
-- Tracking: (leave this empty)
+---
+Start Date: 2020-06-01
+Relevant Team(s): Ember-CLI
+RFC PR: https://github.com/emberjs/rfcs/pull/637
+Tracking: (leave this empty)
+
+---
 
 # Facilitate customization of setupTest* functions
 

--- a/text/0637-customizable-test-setups.md
+++ b/text/0637-customizable-test-setups.md
@@ -2,7 +2,6 @@
 Start Date: 2020-06-01
 Relevant Team(s): Ember-CLI
 RFC PR: https://github.com/emberjs/rfcs/pull/637
-Tracking: (leave this empty)
 
 ---
 

--- a/text/0638-interactive-app-creation.md
+++ b/text/0638-interactive-app-creation.md
@@ -1,7 +1,10 @@
-- Start Date: 2020-06-12
-- Relevant Team(s): ember-cli, framework, learning
-- RFC PR: https://github.com/emberjs/rfcs/pull/638
-- Tracking: (leave this empty)
+---
+Start Date: 2020-06-12
+Relevant Team(s): ember-cli, framework, learning
+RFC PR: https://github.com/emberjs/rfcs/pull/638
+Tracking: (leave this empty)
+
+---
 
 # Interactive New Ember App Creation
 

--- a/text/0638-interactive-app-creation.md
+++ b/text/0638-interactive-app-creation.md
@@ -2,7 +2,6 @@
 Start Date: 2020-06-12
 Relevant Team(s): ember-cli, framework, learning
 RFC PR: https://github.com/emberjs/rfcs/pull/638
-Tracking: (leave this empty)
 
 ---
 

--- a/text/0639-replace-blacklist-whitelist.md
+++ b/text/0639-replace-blacklist-whitelist.md
@@ -1,7 +1,10 @@
-- Start Date: 2020-06-15
-- Relevant Team(s): Ember CLI, Learning
-- RFC PR: [#639](https://github.com/emberjs/rfcs/pull/639)
-- Tracking: (leave this empty)
+---
+Start Date: 2020-06-15
+Relevant Team(s): Ember CLI, Learning
+RFC PR: #639
+Tracking: (leave this empty)
+
+---
 
 # Replace terms blacklist & whitelist in Ember CLI
 

--- a/text/0639-replace-blacklist-whitelist.md
+++ b/text/0639-replace-blacklist-whitelist.md
@@ -1,8 +1,7 @@
 ---
 Start Date: 2020-06-15
 Relevant Team(s): Ember CLI, Learning
-RFC PR: #639
-Tracking: (leave this empty)
+RFC PR: https://github.com/emberjs/rfcs/pull/639
 
 ---
 

--- a/text/0645-add-ember-page-title-addon.md
+++ b/text/0645-add-ember-page-title-addon.md
@@ -1,8 +1,11 @@
-- Start Date: 2020-06-24
-- Relevant Team(s): Ember CLI
-- RFC PR: (after opening the RFC PR, update this with a link to it and update the file name)
-- Tracking: (leave this empty)
-- Authors: Benjamin Jegard, Melanie Sumner, Ricardo Mendes
+---
+Start Date: 2020-06-24
+Relevant Team(s): Ember CLI
+RFC PR: (after opening the RFC PR, update this with a link to it and update the file name)
+Tracking: (leave this empty)
+Authors: Benjamin Jegard, Melanie Sumner, Ricardo Mendes
+
+---
 
 # Add ember-page-title to the app blueprint
 

--- a/text/0645-add-ember-page-title-addon.md
+++ b/text/0645-add-ember-page-title-addon.md
@@ -1,8 +1,7 @@
 ---
 Start Date: 2020-06-24
 Relevant Team(s): Ember CLI
-RFC PR: (after opening the RFC PR, update this with a link to it and update the file name)
-Tracking: (leave this empty)
+RFC PR: https://github.com/emberjs/rfcs/pull/645
 Authors: Benjamin Jegard, Melanie Sumner, Ricardo Mendes
 
 ---

--- a/text/0649-deprecation-staging.md
+++ b/text/0649-deprecation-staging.md
@@ -1,7 +1,10 @@
-- Start Date: June 18, 2020
-- Relevant Team(s): Ember.js, Learning, Steering, Ember CLI
-- RFC PR: https://github.com/emberjs/rfcs/pull/649
-- Tracking:
+---
+Start Date: June 18, 2020
+Relevant Team(s): Ember.js, Learning, Steering, Ember CLI
+RFC PR: https://github.com/emberjs/rfcs/pull/649
+Tracking: 
+
+---
 
 # Deprecation Staging
 

--- a/text/0649-deprecation-staging.md
+++ b/text/0649-deprecation-staging.md
@@ -1,8 +1,7 @@
 ---
-Start Date: June 18, 2020
+Start Date: 2020-06-18
 Relevant Team(s): Ember.js, Learning, Steering, Ember CLI
 RFC PR: https://github.com/emberjs/rfcs/pull/649
-Tracking: 
 
 ---
 

--- a/text/0659-unique-id-helper.md
+++ b/text/0659-unique-id-helper.md
@@ -1,7 +1,10 @@
-- Start Date: 2020-08-25
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/pull/659
-- Tracking: 
+---
+Start Date: 2020-08-25
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/pull/659
+Tracking: 
+
+---
 
 # {{unique-id}} helper
 

--- a/text/0659-unique-id-helper.md
+++ b/text/0659-unique-id-helper.md
@@ -2,7 +2,6 @@
 Start Date: 2020-08-25
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/659
-Tracking: 
 
 ---
 

--- a/text/0671-modernize-built-in-components-1.md
+++ b/text/0671-modernize-built-in-components-1.md
@@ -1,7 +1,10 @@
-- Start Date: 2020-10-02
-- Relevant Team(s): Ember.js
-- RFC PR: https://github.com/emberjs/rfcs/issues/671
-- Tracking: (leave this empty)
+---
+Start Date: 2020-10-02
+Relevant Team(s): Ember.js
+RFC PR: https://github.com/emberjs/rfcs/issues/671
+Tracking: (leave this empty)
+
+---
 
 # Stop Leaking Implementation Details of Built-in Components
 

--- a/text/0671-modernize-built-in-components-1.md
+++ b/text/0671-modernize-built-in-components-1.md
@@ -1,8 +1,7 @@
 ---
 Start Date: 2020-10-02
 Relevant Team(s): Ember.js
-RFC PR: https://github.com/emberjs/rfcs/issues/671
-Tracking: (leave this empty)
+RFC PR: https://github.com/emberjs/rfcs/pull/671
 
 ---
 


### PR DESCRIPTION
- Converts the metadata at the top of the RFCs to real yaml frontmatter
- Fill in missing RFC PR URLs
- Format Start Date consistently