### PR TITLE
Query Params as derived data

### DIFF
--- a/text/0000-query-params-as-derived-data.md
+++ b/text/0000-query-params-as-derived-data.md
@@ -1,0 +1,153 @@
+---
+Stage: Accepted
+Start Date: 2020-01-26
+Release Date: Unreleased
+Release Versions:
+  ember-source: vX.Y.Z
+  ember-data: vX.Y.Z
+Relevant Team(s): Ember.js, Learning
+RFC PR:
+---
+
+<!---
+Directions for above:
+
+Stage: Leave as is
+Start Date: Fill in with today's date, YYYY-MM-DD
+Release Date: Leave as is
+Release Versions: Leave as is
+Relevant Team(s): Fill this in with the [team(s)](README.md#relevant-teams) to which this RFC applies
+RFC PR: Fill this in with the URL for the Proposal RFC PR
+-->
+
+# Query Params as derived data
+
+## Summary
+
+Query Params are awkward in ember in that they align more to the paradigms of a much older
+ember. In the spirit of Octane, this RFC proposes to update how we think about query params
+such that they align with the idea that they are derived state from the URL, much like
+native getters have become in components / services / etc
+
+## Motivation
+
+As taught in [the current version of the guides (3.24)](https://guides.emberjs.com/v3.24.0/routing/query-params/),
+
+Query Params do not currently follow the spirit of Octane:
+ - All data is derived from some source of data
+ - Unidirectional data flow, eliminating "spooky action from a distance"
+
+> All data is derived from some source of data
+
+The source of the data when it comes to Query Params is the URL. With the current way
+Query Params are taught, there are two sources: the URL, and the (sometimes @tracked) property
+on the controller.
+
+```js
+export default class ArticlesController extends Controller {
+  queryParams = ['category'];
+
+  // looks like it could be the source of data, but is also "spookily" overwritten during transitions
+  category = null;
+}
+```
+
+> Unidirectional data flow, eliminating "spooky action from a distance"
+
+There are several ways to update both a query param and the URL.
+With the above example, `category` is _two way bound_ to the URL -- the URL updates `category`,
+and updates to `category` cause transitions to the URL.
+
+Explicit transitions can cause the URL to change, which then cause `category` to change as well.
+
+
+**Proposal**: we teach a more direct way of interacting with query params via "derived data".
+
+Example,
+
+```js
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+export default class ArticlesController extends Controller {
+  @service router;
+
+  queryParams = ['category'];
+
+  get categoryFromQueryParams() {
+    return this.router.currentRouter.queryParams.category;
+  }
+
+  @action
+  updateCategory(value) {
+    this.router.transitionTo({ queryParams: { category: value } });
+  }
+}
+```
+
+The biggest advantage here is that interacting with query params between all class types
+is _consistent_. Changing a query param from a controller, route, component, service, custom class, etc
+can change and access the query params the exact same way. No need to force prop-drilling patterns
+by passing controller properties down many layers of components.
+
+For example, assume there is a compnoent 10+ component layers deep. Instead of passing `@category` and
+`@updateCategory` through each and every one of those component layers, the component can do do:
+
+```js
+import Component from '@glimmer/controller';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+export default class MyDeeplyNestedComponent extends Component {
+  @service router;
+
+  get category() {
+    return this.router.currentRouter.queryParams.category;
+  }
+
+  @action
+  updateCategory(value) {
+    this.router.transitionTo({ queryParams: { category: value } });
+  }
+}
+```
+
+
+## Detailed design
+
+This pattern already works so all that would need updating are the Guides.
+
+## How we teach this
+
+TODO
+
+> What names and terminology work best for these concepts and why? How is this
+idea best presented? As a continuation of existing Ember patterns, or as a
+wholly new one?
+
+> Would the acceptance of this proposal mean the Ember guides must be
+re-organized or altered? Does it change how Ember is taught to new users
+at any level?
+
+> How should this feature be introduced and taught to existing Ember
+users?
+
+## Drawbacks
+
+> Why should we *not* do this? Please consider the impact on teaching Ember,
+on the integration of this feature with other existing and planned features,
+on the impact of the API churn on existing apps, etc.
+
+> There are tradeoffs to choosing any path, please attempt to identify them here.
+
+## Alternatives
+
+> What other designs have been considered? What is the impact of not doing this?
+
+> This section could also include prior art, that is, how other frameworks in the same domain have solved this problem.
+
+## Unresolved questions
+
+> Optional, but suggested for first drafts. What parts of the design are still
+TBD?

--- a/text/0712-query-params-as-derived-data.md
+++ b/text/0712-query-params-as-derived-data.md
@@ -128,6 +128,8 @@ Unchanged
 
 ### Specifying Query Parameters
 
+[Demo Ember Twiddle](https://ember-twiddle.com/9c261e95e3817306711e2107372cd398?openFiles=controllers.articles%5C.js%2C)
+
 Query params are declared on route-driven controllers. For example, to
 configure query params that are active within the `articles` route,
 they must be declared on `controller:articles`.

--- a/text/0712-query-params-as-derived-data.md
+++ b/text/0712-query-params-as-derived-data.md
@@ -211,7 +211,12 @@ With this code, we have established the following behaviors:
 
 ### &lt;LinkTo /&gt; component
 
-TODO
+Unchanged unless RFC 715 is accepted
+ - Due to the sticky-by-default nature of today's query params,
+   the only way to get rid of query params in the URL is to set all query params
+   in a LinkTo to their default values.
+   This can be worked around by not using `<LinkTo>` and instead using the router service's
+   transitionTo method while specifying a `href`-like path.
 
 ### transitionTo
 
@@ -219,19 +224,35 @@ Unchanged
 
 ### Opting in to a full transition
 
-TODO
+Unchanged - this is a route-specific config
 
 ### Update URL with 'replaceState' instead
 
-TODO
+Unchanged - this is a route-specific config
 
 ### Map a controller's property to a different query param key
 
-Removed
+Will need to add a note about getters and other properties in the controller cannot be named the same
+as a query param.
 
 ### Default values and (de)serialization
 
-TODO
+Both default values and deserialization can be handled in getters.
+
+Default value:
+```js
+get category() {
+  return this.router.currentRoute.queryParams.category ?? 'Default Value';
+}
+```
+
+Deserialization:
+```js
+get category() {
+  return parseQP(this.router.currentRoute.queryParams.category);
+}
+```
+`parseQP` defined elsewhere. Receives a string as query params are only ever strings
 
 ### Sticky Query Param Values
 
@@ -247,7 +268,7 @@ supplemental addons, such as ember-parachute.
 
 ### Sticky Query Params
 
-[Demo Ember Twiddle](https://ember-twiddle.com/7e472191b3f5021433b8552158a4379e?openFiles=controllers.articles%5C.js%2C)
+[Demo Ember Twiddle](https://ember-twiddle.com/7e472191b3f5021433b8552158a4379e?openFiles=routes.articles%5C.js%2C&route=%2Farticles)
 _Note that RFC 715 would significantly simplify the implementation_
 
 Sticky query params are supported by controllers by default, but but if someone

--- a/text/0712-query-params-as-derived-data.md
+++ b/text/0712-query-params-as-derived-data.md
@@ -258,76 +258,12 @@ get category() {
 
 ------------------------------------
 
+#### `{ scope: 'controller' }`
 
-Questions from [RFC #715](https://github.com/emberjs/rfcs/pull/715), which takes
-this (#712) RFC a step further and removes the reliance on controllers for query
-params:
+[Demo Ember Twiddle](https://ember-twiddle.com/567b7acf47448cee1f63fcb36e82cd66?openFiles=controllers.articles%5C.js%2C)
 
-Most "fancy features" of query params would be implemented in user-space or in
-supplemental addons, such as ember-parachute.
+This config is not in conflict with derived data.
 
-### Sticky Query Params
-
-[Demo Ember Twiddle](https://ember-twiddle.com/7e472191b3f5021433b8552158a4379e?openFiles=routes.articles%5C.js%2C&route=%2Farticles)
-_Note that RFC 715 would significantly simplify the implementation_
-
-Sticky query params are supported by controllers by default, but but if someone
-wanted to manage that state themselves (for additional features, or providing
-different behavior), they may be able to implement it like this:
-
-```ts
-// app/services/query-params.ts
-const CACHE = new Map<Record<string, string>>();
-
-function getForUrl(url: string) {
-  let existing = CACHE.get(url);
-
-  if (!existing) {
-    CACHE.set(url, {});
-
-    return existing;
-  }
-
-  return existing;
-}
-
-class QueryParamsService extends Service {
-  @service router;
-
-  setQP(qpName, value) {
-    let cacheForUrl = getForUrl(this.router.currentURL);
-
-    cacheForUrl[qpName] = value;
-  }
-
-  getQP(qpName) {
-    return getForUrl(this.router.currentURL)[qpName];
-  }
-}
-```
-
-```js
-// some route
-export default MyRoute extends Route {
-  @service router;
-  @service queryParams;
-
-  async beforeModel({ to: { queryParams }}) {
-    let category = this.queryParams.getQP('category');
-
-    // if transitioning to a route with explicit query params,
-    // update the query param cache
-    if (stickyQPs.category && category !== queryParams.category) {
-      this.queryParams.setQP('category', queryParams.category);
-    }
-
-    // because the URL must reflect the state query params, we must transition
-    if (!queryParams.category && category) {
-      this.router.transitionTo({ queryParams: { category }});
-    }
-  }
-}
-```
 
 ### Default Query Params
 

--- a/text/0712-query-params-as-derived-data.md
+++ b/text/0712-query-params-as-derived-data.md
@@ -95,7 +95,7 @@ For example, assume there is a component 10+ component layers deep. Instead of p
 `@updateCategory` through each and every one of those component layers, the component can do:
 
 ```js
-import Component from '@glimmer/controller';
+import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 

--- a/text/0712-query-params-as-derived-data.md
+++ b/text/0712-query-params-as-derived-data.md
@@ -76,7 +76,7 @@ export default class ArticlesController extends Controller {
   queryParams = ['category'];
 
   get categoryFromQueryParams() {
-    return this.router.currentRouter.queryParams.category;
+    return this.router.currentRoute.queryParams.category;
   }
 
   @action

--- a/text/0712-query-params-as-derived-data.md
+++ b/text/0712-query-params-as-derived-data.md
@@ -323,7 +323,7 @@ export default MyRoute extends Route {
 }
 ```
 
-### Does &lt;Route&gt;#refrosh() retain query params?
+### Does &lt;Route&gt;#refresh() retain query params?
 
 yes
 

--- a/text/0712-query-params-as-derived-data.md
+++ b/text/0712-query-params-as-derived-data.md
@@ -247,6 +247,9 @@ supplemental addons, such as ember-parachute.
 
 ### Sticky Query Params
 
+[Demo Ember Twiddle](https://ember-twiddle.com/7e472191b3f5021433b8552158a4379e?openFiles=controllers.articles%5C.js%2C)
+_Note that RFC 715 would significantly simplify the implementation_
+
 Sticky query params are supported by controllers by default, but but if someone
 wanted to manage that state themselves (for additional features, or providing
 different behavior), they may be able to implement it like this:

--- a/text/0712-query-params-as-derived-data.md
+++ b/text/0712-query-params-as-derived-data.md
@@ -103,7 +103,7 @@ export default class MyDeeplyNestedComponent extends Component {
   @service router;
 
   get category() {
-    return this.router.currentRouter.queryParams.category;
+    return this.router.currentRoute.queryParams.category;
   }
 
   @action

--- a/text/0712-query-params-as-derived-data.md
+++ b/text/0712-query-params-as-derived-data.md
@@ -91,8 +91,8 @@ is _consistent_. Changing a query param from a controller, route, component, ser
 can change and access the query params the exact same way. No need to force prop-drilling patterns
 by passing controller properties down many layers of components.
 
-For example, assume there is a compnoent 10+ component layers deep. Instead of passing `@category` and
-`@updateCategory` through each and every one of those component layers, the component can do do:
+For example, assume there is a component 10+ component layers deep. Instead of passing `@category` and
+`@updateCategory` through each and every one of those component layers, the component can do:
 
 ```js
 import Component from '@glimmer/controller';

--- a/text/0712-query-params-as-derived-data.md
+++ b/text/0712-query-params-as-derived-data.md
@@ -6,7 +6,7 @@ Release Versions:
   ember-source: vX.Y.Z
   ember-data: vX.Y.Z
 Relevant Team(s): Ember.js, Learning
-RFC PR:
+RFC PR: https://github.com/emberjs/rfcs/pull/712
 ---
 
 <!---

--- a/text/0712-query-params-as-derived-data.md
+++ b/text/0712-query-params-as-derived-data.md
@@ -207,13 +207,13 @@ With this code, we have established the following behaviors:
    `setupController`, etc.); it will only update the URL.
 
 
-### <LinkTo /> component
+### &lt;LinkTo /&gt; component
 
 TODO
 
 ### transitionTo
 
-TODO
+Unchanged
 
 ### Opting in to a full transition
 
@@ -240,7 +240,8 @@ Questions from [RFC #715](https://github.com/emberjs/rfcs/pull/715), which takes
 this (#712) RFC a step further and removes the reliance on controllers for query
 params:
 
-Most "fancy features" of query params would be implemented in user-space:
+Most "fancy features" of query params would be implemented in user-space or in
+supplemental addons, such as ember-parachute.
 
 ### Sticky Query Params
 
@@ -320,7 +321,7 @@ export default MyRoute extends Route {
 }
 ```
 
-### Does <Route>#refrosh() retain query params?
+### Does &lt;Route&gt;#refrosh() retain query params?
 
 yes
 


### PR DESCRIPTION
[rendered](https://github.com/nullvoxpopuli/rfcs/blob/update-query-param-docs/text/0712-query-params-as-derived-data.md)

This RFC is part of a series of RFCs to lead to the _deprecation_ of controllers entirely. For more about how I imagine that happening, let's talk on Discord / keep the RFCs themselves focused on the topic they're about.


 Related RFCs:
  - [Arbitrary Query Params](https://github.com/emberjs/rfcs/pull/715)
     - would affect the proposed Ember Guides changes mentioned in this (#712) RFC, in that, all mentions of controllers would be removed (after both #712 and #715, an app can opt out of controllers entirely)
     - #712 and #715 are closely related
    
  - [An Alternative to Controllers](https://github.com/emberjs/rfcs/pull/499)
    - explores some ideas that are similar to what have been discussed recently with template-imports in the [#st-template-imports](https://discord.com/channels/480462759797063690/518154533143183377/815728311841062944) channel in discord
    - needs a good amount of revisions