### PR TITLE
Swap get-changed-files action for another 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,18 @@ jobs:
         run: node lint-rfc-frontmatter.js ../text/*.md || true # Don't want to fail on old RFCs just yet
         working-directory: rfcs-tooling
 
-      - id: files
-        uses: jitterbit/get-changed-files@v1
+      - name: Get Changed Files
+        uses: lots0logs/gh-action-get-changed-files@2.1.4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Filter Added Files to added RFCs
+        id: files
+        run: |
+          added_files=`jq -r '[.[] | select(startswith("text/"))] | join(" ")' ${HOME}/files_added.json`
+          echo "::set-output name=added::$added_files"
 
       - name: Lint added RFCs frontmatter
         if: ${{ steps.files.outputs.added }}
         run: |
-          for changed_file in ${{ steps.files.outputs.added }}; do
-            node lint-rfc-frontmatter.js ../${changed_file}
-          done
-        working-directory: rfcs-tooling
+          node rfcs-tooling/lint-rfc-frontmatter.js ${{ steps.files.outputs.added }}

--- a/.github/workflows/ensure-filename.yml
+++ b/.github/workflows/ensure-filename.yml
@@ -10,8 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - id: files
-        uses: jitterbit/get-changed-files@v1
+
+      - name: Get Changed Files
+        uses: lots0logs/gh-action-get-changed-files@2.1.4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Filter Added Files to Added RFCs
+        id: files
+        run: |
+          added_files=`jq -r '[.[] | select(startswith("text/"))] | join(" ")' ${HOME}/files_added.json`
+          echo "::set-output name=added::$added_files"
+
       - name: Checkout tools repo
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
(it was responsible for "the head commit is not ahead of the base commit" message).

This also corrects a major oversight from before where it would attempt to lint any added file, not just one that is an RFC.

The usage of this action can eventually go away in `lint-frontmatter` (once stages frontmatter is fully backfilled). 