### PR TITLE
Update 0460-yieldable-named-blocks.md

### DIFF
--- a/text/0460-yieldable-named-blocks.md
+++ b/text/0460-yieldable-named-blocks.md
@@ -187,7 +187,7 @@ AngleBracketWithBlock :
   "</" ComponentTag ">"
 
 AngleBracketWithBlocks :
-  "<" ComponentTag ComponentArgs? BlockParams? ">"
+  "<" ComponentTag ComponentArgs? ">"
   NamedBlock+
   "</" ComponentTag ">"
 


### PR DESCRIPTION
Tweaked the grammar for ComponentWithBlocks, as only the blocks can have block params and not the component.