### PR TITLE
RFC 0418 - Fix value of key `into`

### DIFF
--- a/text/0418-deprecate-route-render-methods.md
+++ b/text/0418-deprecate-route-render-methods.md
@@ -116,7 +116,7 @@ export default Route.extend({
   renderTemplate() {
     if (this.user.isLoggedIn) {
       this.render('account', {
-        into: 'applcation',
+        into: 'authenticated',
         outlet: 'account',
         controller: 'account'
       });


### PR DESCRIPTION
Just a small typo, `render()` uses `into: 'applcation'` while the above example shows the template `authenticated`.