### PR TITLE
ember-data: Return a Promise from Model.save()

### DIFF
--- a/text/0795-ember-data-return-promise-save.md
+++ b/text/0795-ember-data-return-promise-save.md
@@ -1,0 +1,70 @@
+---
+Stage: Proposed
+Start Date: 2022-02-13
+Release Date: Unreleased
+Release Versions:
+  ember-source: vX.Y.Z
+  ember-data: vX.Y.Z
+Relevant Team(s): ember-data 
+RFC PR: https://github.com/emberjs/rfcs/pull/795
+---
+
+# Return a Promise from Model.save()
+
+## Summary
+
+Model.save() will return an RSVP.Promise wrapper instead of a PromiseObject.
+
+## Motivation
+
+* The API documentation already documents the return value as a Promise.
+* Remove dependency on promise proxies
+* Async Consistency - The PromiseObject encourages a usage pattern of sometimes-async, sometimes-sync behavior. We want to [reduce zalgo](http://blog.izs.me/post/59142742143/designing-apis-for-asynchrony).
+* API consistency - While the PromiseObject proxies properties, the PromiseObject does not proxy methods on the underlying model. For instance, if you try to call a method like destroyRecord on the model, you will get a “not a function” error because the method is called on the Proxy and not the underlying model. This encourages users for Ember Data to reach into private implementation details of the promise proxy, such as using proxy.get('content') to call methods.
+* Enable new functionality in Ember Data while making backwards compatibility with older versions of Ember easier.
+* The documentation of using PromiseProxy APIs has been replaced over time in the guides and API documentation to use more typical JavaScript usage of Promises, such as async/await, instead of PromiseProxies.
+
+## Detailed design
+
+Introduce a new feature flag, `DS_MODEL_SAVE_PROMISE`, Model.save() will return an an RSVP.Promise wrapper that resolves with the model if the save was successful, or rejects with an error if the save fails. Moreover, `isPending`, `isResolved`, and `isRejected` will be exposed as derived state on the promise.  When disabled, a PromiseObject will be returned to keep today's behavior, but accessing properties on the PromiseObject or calling non-Promise functions (.then, .finally, .catch) on the PromiseObject will issue a deprecation warning.
+
+Deprecation Plan:
+
+The deprecations can be implemented by adding deprecations around the existing PromiseObject. However, we can't include the deprecations in the actual PromiseObject class because [it is the base class for the relationship proxies](https://github.com/emberjs/data/blob/master/addon/-legacy-private/system/promise-proxies.js#L85). Instead, we can create and use a new DeprecatedPromiseObject for the DS.Model.save() function. It functions like a PromiseObject but deprecates the following behavior:
+
+    * Accessing properties on the PromiseObject returned from DS.Model.save()
+        * Use deprecateProperty from Ember to deprecate all the properties that the PromiseProxy Mixin provides. The list of properties can be found here: https://github.com/emberjs/ember.js/blob/master/packages/ember-runtime/lib/mixins/promise_proxy.js
+        * Deprecate accessing any unknown properties. For instance, someone might try to grab the value of an attr or computed property from a model, e.g. proxy.get('email').
+    * Calling functions that are not available on RSVP.Promises
+        * Not Safe (issue deprecation): .get/.set/anything else really
+        * Safe (do not issue a deprecation): .then, .catch, .finally
+
+The implementation follows the standard feature-flagging process in Ember and Ember Data. The final implementation will look something like:
+
+```
+  save(options) {
+    const savePromise = this._internalModel.save(options).then(() => this);
+    
+    if (DS_MODEL_SAVE_PROMISE) {
+      return savePromise;
+    } else {
+      return DeprecatedPromiseObject.create({
+        promise: savePromise
+      });
+    }
+  },
+```
+
+## How we teach this
+
+We do not believe this requires any update to the Ember curriculum. API documentation does not need to be updated as it is already documented as returning a promise. This behavior of accessing properties through the PromiseProxyMixin specifically for DS.Model.save() is not documented in the guides.
+
+## Drawbacks
+
+For users relying on this behavior, they may have to refactor their code to access model properties and methods, especially if they were reaching for private APIs.
+
+## Alternatives
+
+The impact of not doing this prevents further changes in Ember Data.
+
+## Unresolved questions

--- a/text/0795-ember-data-return-promise-save.md
+++ b/text/0795-ember-data-return-promise-save.md
@@ -13,7 +13,7 @@ RFC PR: https://github.com/emberjs/rfcs/pull/795
 
 ## Summary
 
-Model.save() will return an RSVP.Promise wrapper instead of a PromiseObject.
+Model.save() will return a Promise wrapper instead of a PromiseObject.
 
 ## Motivation
 
@@ -26,7 +26,7 @@ Model.save() will return an RSVP.Promise wrapper instead of a PromiseObject.
 
 ## Detailed design
 
-Introduce a new feature flag, `DS_MODEL_SAVE_PROMISE`, Model.save() will return an an RSVP.Promise wrapper that resolves with the model if the save was successful, or rejects with an error if the save fails. Moreover, `isPending`, `isResolved`, and `isRejected` will be exposed as derived state on the promise.  When disabled, a PromiseObject will be returned to keep today's behavior, but accessing properties on the PromiseObject or calling non-Promise functions (.then, .finally, .catch) on the PromiseObject will issue a deprecation warning.
+Introduce a new feature flag, `DS_MODEL_SAVE_PROMISE`, Model.save() will return an an Promise wrapper that resolves with the model if the save was successful, or rejects with an error if the save fails. Moreover, `isPending`, `isResolved`, and `isRejected` will be exposed as derived state on the promise.  When disabled, a PromiseObject will be returned to keep today's behavior, but accessing properties on the PromiseObject or calling non-Promise functions (.then, .finally, .catch) on the PromiseObject will issue a deprecation warning.
 
 Deprecation Plan:
 
@@ -35,7 +35,7 @@ The deprecations can be implemented by adding deprecations around the existing P
     * Accessing properties on the PromiseObject returned from DS.Model.save()
         * Use deprecateProperty from Ember to deprecate all the properties that the PromiseProxy Mixin provides. The list of properties can be found here: https://github.com/emberjs/ember.js/blob/master/packages/ember-runtime/lib/mixins/promise_proxy.js
         * Deprecate accessing any unknown properties. For instance, someone might try to grab the value of an attr or computed property from a model, e.g. proxy.get('email').
-    * Calling functions that are not available on RSVP.Promises
+    * Calling functions that are not available on Promises
         * Not Safe (issue deprecation): .get/.set/anything else really
         * Safe (do not issue a deprecation): .then, .catch, .finally
 
@@ -65,6 +65,8 @@ For users relying on this behavior, they may have to refactor their code to acce
 
 ## Alternatives
 
-The impact of not doing this prevents further changes in Ember Data.
+- The impact of not doing this prevents further changes in Ember Data.
+- We could just return a promise instead of wrapper around the promise.
+- Return a promise but also exposing a template/js helper in a new package that wraps any promise exposing these flags providing broader utility without imposing this promise-state management on ember-data itself.
 
 ## Unresolved questions


### PR DESCRIPTION
Partial dup of https://github.com/emberjs/rfcs/pull/362#issuecomment-553646135 with improvements.  Specifically the addition of derived state to the promise wrapper.

[rendered](https://github.com/snewcomer/rfcs/blob/sn/model-save/text/0795-ember-data-return-promise-save.md)