### PR TITLE
Add release versions for RFCs released between 3.25 and 4.1

### DIFF
--- a/text/0236-deprecation-ember-string.md
+++ b/text/0236-deprecation-ember-string.md
@@ -1,5 +1,9 @@
 ---
+Stage: Accepted
 Start Date: 2017-07-14
+Release Date: Unreleased
+Release Versions:
+  ember-source: vX.Y.Z
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/236
 Tracking: https://github.com/emberjs/rfc-tracking/issues/26

--- a/text/0308-deprecate-property-lookup-fallback.md
+++ b/text/0308-deprecate-property-lookup-fallback.md
@@ -1,5 +1,10 @@
 ---
+Stage: Released
 Start Date: 2018-02-15
+Release Date: 2021-03-22
+Release Versions:
+  ember-source: v3.26.0
+Relevant Teams: Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/308
 
 ---

--- a/text/0418-deprecate-route-render-methods.md
+++ b/text/0418-deprecate-route-render-methods.md
@@ -1,5 +1,9 @@
 ---
+Stage: Released
 Start Date: 2018-19-12
+Release Date: 2021-05-03
+Release Versions:
+  ember-source: v3.27.0
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/418
 Tracking: https://github.com/emberjs/rfc-tracking/issues/30

--- a/text/0432-contextual-helpers.md
+++ b/text/0432-contextual-helpers.md
@@ -1,9 +1,12 @@
 ---
+Stage: Released
 Start Date: 2018-12-17
+Release Date: 2021-05-03
+Release Versions:
+  ember-source: v3.27.0
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/432
 Tracking: https://github.com/emberjs/rfc-tracking/issues/6
-
 ---
 
 # Contextual Helpers and Modifiers (a.k.a. "first-class helpers/modifiers")

--- a/text/0445-deprecate-with.md
+++ b/text/0445-deprecate-with.md
@@ -1,5 +1,9 @@
 ---
+Stage: Released
 Start Date: 2019-02-13
+Release Date: 2021-03-22
+Release Versions:
+  ember-source: v3.26.0
 Relevant Teams: Ember.js, Learning
 RFC PR: https://github.com/emberjs/rfcs/pull/445
 Tracking: https://github.com/emberjs/rfc-tracking/issues/40

--- a/text/0460-yieldable-named-blocks.md
+++ b/text/0460-yieldable-named-blocks.md
@@ -1,5 +1,9 @@
 ---
+Stage: Released
 Start Date: 2019-03-06
+Release Date: 2021-02-08
+Release Versions:
+  ember-source: v3.25.0
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/460
 

--- a/text/0491-deprecate-disconnect-outlet.md
+++ b/text/0491-deprecate-disconnect-outlet.md
@@ -1,5 +1,9 @@
 ---
+Stage: Released
 Start Date: 2019-05-20
+Release Date: 2021-05-03
+Release Versions:
+  ember-source: v3.27.0
 Relevant Team(s): Ember.js, Learning
 RFC PR: https://github.com/emberjs/rfcs/pull/491
 

--- a/text/0496-handlebars-strict-mode.md
+++ b/text/0496-handlebars-strict-mode.md
@@ -1,5 +1,9 @@
 ---
+Stage: Released
 Start Date: 2019-02-14
+Release Date: 2021-05-03
+Release Versions:
+  ember-source: v3.27.0
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/496
 

--- a/text/0566-memo-decorator.md
+++ b/text/0566-memo-decorator.md
@@ -1,10 +1,9 @@
 ---
-Stage: Accepted
+Stage: Released
 Start Date: 2019-12-22
-Release Date: Unreleased
+Release Date: 2021-12-28
 Release Versions:
-  ember-source: vX.Y.Z
-  ember-data: vX.Y.Z
+  ember-source: v4.1.0
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/566
 ---

--- a/text/0631-refresh-method-for-router-service.md
+++ b/text/0631-refresh-method-for-router-service.md
@@ -1,5 +1,9 @@
 ---
+Stage: Released
 Start Date: 2020-05-23
+Release Date: 2021-12-28
+Release Versions:
+  ember-source: v4.1.0
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/631
 

--- a/text/0671-modernize-built-in-components-1.md
+++ b/text/0671-modernize-built-in-components-1.md
@@ -1,5 +1,9 @@
 ---
+Stage: Released
 Start Date: 2020-10-02
+Release Date: 2021-05-03
+Release Versions:
+  ember-source: v3.27.0
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/671
 

--- a/text/0674-deprecate-transition-methods-of-controller-and-route.md
+++ b/text/0674-deprecate-transition-methods-of-controller-and-route.md
@@ -1,5 +1,9 @@
 ---
+Stage: Released
 Start Date: 2020-10-12
+Release Date: 2021-03-22
+Release Versions:
+  ember-source: v3.26.0
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/674
 

--- a/text/0680-implicit-injection-deprecation.md
+++ b/text/0680-implicit-injection-deprecation.md
@@ -1,10 +1,9 @@
 ---
-Stage: Accepted
+Stage: Released
 Start Date: 2020-10-04
-Release Date: Unreleased
+Release Date: 2021-11-15
 Release Versions:
-  ember-source: vX.Y.Z
-  ember-data: vX.Y.Z
+  ember-source: v4.0.0
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/680
 ---

--- a/text/0685-new-browser-support-policy.md
+++ b/text/0685-new-browser-support-policy.md
@@ -1,10 +1,9 @@
 ---
-Stage: Accepted
+Stage: Released
 Start Date: 2020-11-28
-Release Date: Unreleased
+Release Date: 2021-11-15
 Release Versions:
-  ember-source: vX.Y.Z
-  ember-data: vX.Y.Z
+  ember-source: v4.0.0
 Relevant Team(s): All
 RFC PR: https://github.com/emberjs/rfcs/pull/685
 ---

--- a/text/0686-deprecate-old-manager-capabilities-versions.md
+++ b/text/0686-deprecate-old-manager-capabilities-versions.md
@@ -1,10 +1,9 @@
 ---
-Stage: Accepted
+Stage: Released
 Start Date: 2020-11-28
-Release Date: Unreleased
+Release Date: 2021-03-22
 Release Versions:
-  ember-source: vX.Y.Z
-  ember-data: vX.Y.Z
+  ember-source: v3.26.0
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/686
 ---

--- a/text/0689-deprecate-has-block.md
+++ b/text/0689-deprecate-has-block.md
@@ -1,10 +1,9 @@
 ---
-Stage: Accepted
+Stage: Released
 Start Date: 2020-12-22
-Release Date: Unreleased
+Release Date: 2021-03-22
 Release Versions:
-  ember-source: vX.Y.Z
-  ember-data: vX.Y.Z
+  ember-source: v3.26.0
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/689
 ---

--- a/text/0690-deprecate-attrs-in-templates.md
+++ b/text/0690-deprecate-attrs-in-templates.md
@@ -1,10 +1,9 @@
 ---
-Stage: Accepted
+Stage: Released
 Start Date: 2020-12-22
-Release Date: Unreleased
+Release Date: 2021-03-22
 Release Versions:
-  ember-source: vX.Y.Z
-  ember-data: vX.Y.Z
+  ember-source: v3.26.0
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/690
 ---

--- a/text/0691-deprecate-class-binding-and-class-name-bindings.md
+++ b/text/0691-deprecate-class-binding-and-class-name-bindings.md
@@ -1,10 +1,9 @@
 ---
-Stage: Accepted
+Stage: Released
 Start Date: 2020-12-22
-Release Date: Unreleased
+Release Date: 2021-03-22
 Release Versions:
-  ember-source: vX.Y.Z
-  ember-data: vX.Y.Z
+  ember-source: v3.26.0
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/691
 ---

--- a/text/0692-deprecate-array-observers.md
+++ b/text/0692-deprecate-array-observers.md
@@ -1,10 +1,9 @@
 ---
-Stage: Accepted
+Stage: Released
 Start Date: 2020-12-23
-Release Date: Unreleased
+Release Date: 2021-03-22
 Release Versions:
-  ember-source: vX.Y.Z
-  ember-data: vX.Y.Z
+  ember-source: v3.26.0
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/692
 ---

--- a/text/0698-deprecate-link-to-positional-arguments.md
+++ b/text/0698-deprecate-link-to-positional-arguments.md
@@ -1,10 +1,9 @@
 ---
-Stage: Accepted
+Stage: Released
 Start Date: 2021-01-05
-Release Date: Unreleased
+Release Date: 2021-03-22
 Release Versions:
-  ember-source: vX.Y.Z
-  ember-data: vX.Y.Z
+  ember-source: v3.26.0
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/698
 ---

--- a/text/0704-deprecate-octane-optional-features.md
+++ b/text/0704-deprecate-octane-optional-features.md
@@ -1,10 +1,9 @@
 ---
-Stage: Accepted
+Stage: Released
 Start Date: 2020-01-14
-Release Date: Unreleased
+Release Date: 2021-03-22
 Release Versions:
-  ember-source: vX.Y.Z
-  ember-data: vX.Y.Z
+  ember-source: v3.26.0
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/704
 ---

--- a/text/0705-deprecate-jquery-optional-feature.md
+++ b/text/0705-deprecate-jquery-optional-feature.md
@@ -1,10 +1,9 @@
 ---
-Stage: Accepted
+Stage: Released
 Start Date: 2020-01-14
-Release Date: Unreleased
+Release Date: 2021-03-22
 Release Versions:
-  ember-source: vX.Y.Z
-  ember-data: vX.Y.Z
+  ember-source: v3.26.0
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/705
 ---

--- a/text/0706-deprecate-ember-global.md
+++ b/text/0706-deprecate-ember-global.md
@@ -1,10 +1,9 @@
 ---
-Stage: Accepted
+Stage: Released
 Start Date: 2020-14-01
-Release Date: Unreleased
+Release Date: 2021-05-03
 Release Versions:
-  ember-source: vX.Y.Z
-  ember-data: vX.Y.Z
+  ember-source: v3.27.0
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/706
 ---

--- a/text/0711-deprecate-auto-location.md
+++ b/text/0711-deprecate-auto-location.md
@@ -1,10 +1,9 @@
 ---
-Stage: Accepted
+Stage: Released
 Start Date: 2021-01-23
-Release Date: Unreleased
+Release Date: 2021-12-28
 Release Versions:
-  ember-source: vX.Y.Z
-  ember-data: vX.Y.Z
+  ember-source: v4.1.0
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/711
 ---

--- a/text/0750-deprecate-ember-assign.md
+++ b/text/0750-deprecate-ember-assign.md
@@ -1,10 +1,9 @@
 ---
-Stage: Accepted
+Stage: Released
 Start Date: 2021-05-26
-Release Date: Unreleased
+Release Date: 2021-11-15
 Release Versions:
-  ember-source: vX.Y.Z
-  ember-data: vX.Y.Z
+  ember-source: v4.0.0
 Relevant Team(s): Ember.js
 RFC PR: https://github.com/emberjs/rfcs/pull/750
 ---

--- a/text/0752-inject-service.md
+++ b/text/0752-inject-service.md
@@ -1,10 +1,9 @@
 ---
-Stage: Accepted
+Stage: Released
 Start Date: 2021-06-10
-Release Date: Unreleased
+Release Date: 2021-12-28
 Release Versions:
-  ember-source: vX.Y.Z
-  ember-data: vX.Y.Z
+  ember-source: v4.1.0
 Relevant Team(s): Ember.js, Learning
 RFC PR: https://github.com/emberjs/rfcs/pull/752
 ---

--- a/text/0772-deprecate-bower-support.md
+++ b/text/0772-deprecate-bower-support.md
@@ -1,10 +1,9 @@
 ---
-Stage: Accepted
+Stage: Ready for Release
 Start Date: 2021-10-21
 Release Date: Unreleased
 Release Versions:
-  ember-source: vX.Y.Z
-  ember-data: vX.Y.Z
+  ember-cli: vX.Y.Z
 Relevant Team(s): Ember CLI
 RFC PR: https://github.com/emberjs/rfcs/pull/772
 ---


### PR DESCRIPTION
Recent RFCs didn't have updated stage, release date, release versions.

Added such details for RFCs released between Ember.js versions 3.25 and 4.1