### PR TITLE
Add TypeScript team to teams list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ further guidance.
 | Ember Data    | Ember Data                                                   |
 | Ember CLI     | Ember CLI                                                    |
 | Learning      | Documentation, Website, learning experiences                 |
+| TypeScript    | TypeScript integration and design                            |
 | Steering      | Governance                                                   |
  
 ### Finding a champion


### PR DESCRIPTION
Just what it says on the tin. Missed this when I did all the other administrative bits!