### PR TITLE
fix image urls in embedded images

### DIFF
--- a/text/0023-command-line-completion.md
+++ b/text/0023-command-line-completion.md
@@ -9,8 +9,6 @@ RFC PR: https://github.com/ember-cli/rfcs/pull/23
 
 Adds command line completion *(tab completion)* to ember-cli that fills in partially typed commands by the user and suggests available sub commands or options. *(from now on i will refer to "strings in the command line" as "cli-commands" and "generate" and "new" as unprefixed "commands")*
 
-![](http://zippy.gfycat.com/PrestigiousLoneHalicore.gif)
-
 # Motivation
 
 With all the already existing commands and especially all blueprints, plus the fact that any addon can add even more blueprints to your tool kit, users can get overwhelmed. Currently, when you want to execute a specific task and you don't quite know the correct cli-command you have to invoke `ember help` which is noisy and slow *( especially when you just want to know the spelling of a specific thing)*. This feature will enable the user to choose from all existing cli-commands by pressing __[tab]__ or just to let ember-cli fill partially typed cli-commands for speed.

--- a/text/0425-website-redesign.md
+++ b/text/0425-website-redesign.md
@@ -27,13 +27,13 @@ A visual redesign is a bit different than most of the Code RFCs, so showing beco
 
 Like any good design project, we expect changes along the way, but that these comps present the primary thrust and look/feel of the things that have not yet been designed.
 
-[![Comp 1](../images/website_1.png)](https://user-images.githubusercontent.com/2922250/50390285-67d7c100-0703-11e9-9841-f3d3b4d34f7f.png)
+![Comp 1](/images/website_1.png)
 
 Much of the copy is placeholder, but much of it represents concrete thought. A lot of that content was gleaned from a survey of about 200 of our most active users, who told us that they most value *clear best practices* and *productivity*.
 
-![Survey Results](../images/survey_results.png)
+![Survey Results](/images/survey_results.png)
 
-[A significantly detailed write up of the survey results can be found here](../images/survey_results_analysis.pdf). Various team members reviewed the results, and then worked together [to outline copy for the website based on the feedback](../images/EmberJS_Homepage_Outline.pdf). The goal was to reach consensus on what the homepage should communicate, disregarding design, aesthetic, and code.
+[A significantly detailed write up of the survey results can be found here](/images/survey_results_analysis.pdf). Various team members reviewed the results, and then worked together [to outline copy for the website based on the feedback](/images/EmberJS_Homepage_Outline.pdf). The goal was to reach consensus on what the homepage should communicate, disregarding design, aesthetic, and code.
 
 The hierarchy of the first comp that resulted from that outline was deliberate—for example, the Social Proof section comes first right after the Hero, since it’s the next most important section. This hierarchy will continue to be apparent in the final design. The general instructions provided to the designer was that a tone of "friendly professional" was ideal, building on Ember's deliberately optimistic and friendly look and feel (and mascot!) up until now.
 
@@ -65,9 +65,9 @@ The exact *plan* for this will have to be developed next, hence, unresolved.
 
 Some areas of the primary comp came with more detailed design views. Those can be seen here:
 
-* [Header Dropdowns](../images/website_2_header_dropdown.png)
-* [URL Examples](../images/website_3_url_examples.png)
-* [Button UI](../images/website_4-button_ui.png)
-* [Scrolled Nav, Concept 1](../images/website_5_scrolled_nav.png)
-* [Scrolled Nav, Concept 2](../images/website_6_nav_alt.png)
-* [Pointer](../images/website_7_pointer.png)
+* [Header Dropdowns](/images/website_2_header_dropdown.png)
+* [URL Examples](/images/website_3_url_examples.png)
+* [Button UI](/images/website_4-button_ui.png)
+* [Scrolled Nav, Concept 1](/images/website_5_scrolled_nav.png)
+* [Scrolled Nav, Concept 2](/images/website_6_nav_alt.png)
+* [Pointer](/images/website_7_pointer.png)

--- a/text/0457-nested-lookups.md
+++ b/text/0457-nested-lookups.md
@@ -16,7 +16,7 @@ Create a syntax for invoking components nested inside of directories in angle-br
 
 Today's angle-bracket syntax conversion guide says this:
 
-![existing documentation](../images/457-when-to-use-curlies.jpg)
+![existing documentation](/images/457-when-to-use-curlies.jpg)
 
 This has been an acceptable interim step as we have worked on completing the work of revamping the component model, but it's a source of incoherence (and a reported adoption blocker for some apps) in the Ember design, and we need to eliminate this source of incoherence in order to recommend angle bracket components in the Octane edition.
 
@@ -95,7 +95,7 @@ We currently don't cover directory nesting in the guides, and directory nesting 
 
 RFC #311 introduced a normalization rule for angle bracket invocation, and the guides mention that `<NavBar>` invokes a component that appears in the file system as `nav-bar`.
 
-![rental-listing in the docs](../images/457-dasherization.jpg)
+![rental-listing in the docs](/images/457-dasherization.jpg)
 
 After this RFC, the documentation should add a "Zoey says" sidebar that describes the rule in more detail, and mentions that you can refer to components nested in a directory with the `::` separator.
 
@@ -120,7 +120,7 @@ On the other hand, it has poor syntax highlighting in virtually all existing hig
 
 Additionally, some autocomplete systems assume that `<AppIcons/` is the beginning of a self-closing tag.
 
-![an example of an IDE confusing this syntax as a self-closing tag](../images/457-autocomplete-problem.gif)
+![an example of an IDE confusing this syntax as a self-closing tag](/images/457-autocomplete-problem.gif)
 
 Another drawback of this proposal is that it uses `::` syntax for today's templates, and we don't expect that syntax to be relevant to templates using template imports. It's possible that we would want to use this syntax, which might be considered valuable, in templates using template imports. That said, there is no specific proposal for what we might want to use this syntax for, and we could compatibly reclaim it in the context of template imports, at the cost of some mental churn.
 


### PR DESCRIPTION
There are 2 rfcs that have embedded images https://rfcs.emberjs.com/id/0425-website-redesign and https://rfcs.emberjs.com/id/0457-nested-lookups but those images don't work in the new implementation of the website with the kind of relative urls that they are using.

Changing these images so that they work in the new app also has no effect on the preview rendering of GitHub, both places where you might want to see the images work fine after this change 👍 ([click here to see an example](https://github.com/mansona/rfcs/blob/89c0ab41d19a5221adcbcdd5e599be93d29287ad/text/0425-website-redesign.md))

Edit: I also removed a dead link to a gif that was added 7 years ago 👍 