### PR TITLE
Amend RFC 0821 given implementation tweaks

### DIFF
--- a/text/0821-public-types.md
+++ b/text/0821-public-types.md
@@ -239,7 +239,7 @@ Although users will not usually need to use it directly, instead simply passing 
 import { type FullName } from '@ember/owner';
 ```
 
-S users can refer to it in JSDoc comments using `import()` syntax:
+JS users can refer to it in JSDoc comments using `import()` syntax:
 
 ```js
 /**


### PR DESCRIPTION
Authoring [the types for DefinitelyTyped][dt] revealed a number of issues, which were also surfaced previously while working on Ember's internal versions of these types. Accordingly, align the types as defined here with Ember's internal representation of them, and clarify why the types are the way they are when they may not seem especially sensical. Also add a `FullName` export for convenience.

[dt]: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61533

As a bonus, add a table of contents and make sure the order of the sections matches the order described in prose.