### PR TITLE
update rfc-tooling to allow null for release-date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
         with:
           repository: emberjs/rfcs-tooling
           path: rfcs-tooling
-          ref: 'v1.0.0'
+          ref: 'v1.1.0'
 
       - uses: actions/setup-node@v3
 
       - run: yarn install
         working-directory: rfcs-tooling
 
-      - name: Lint the frontmatter of all RFCs for informational purposes
+      - name: Lint the frontmatter of all RFCs
         run: node ./rfcs-tooling/lint-rfc-frontmatter.js text/*.md


### PR DESCRIPTION
This should make the CI green again 🎉 and from this point on we shouldn't merge anything unless it passes validation so that we don't break the rendering of rfcs.emberjs.com 👍 