### PR TITLE
Amend RFC 0821: add Resolver public type

### DIFF
--- a/text/0821-public-types.md
+++ b/text/0821-public-types.md
@@ -395,23 +395,28 @@ function takesRouteInfoWithAttributes(routeInfoWithAttributes) {
 
 ### `Resolver`
 
-The resolver is a contract implemented by libraries outside Ember itself, such as `ember-resolver`, `ember-strict-resolver`, and any number of custom resolvers which exist in apps across the ecosystem. It has never had public documentation, but is fully public API. It is a user-constructible interface with the following definition (using the `Factory` and `FullName` types exported from the new `@ember/owner` module), available as a new named type-only export from the `@ember/engine` package:
+The resolver is a contract implemented by libraries outside Ember itself, such as `ember-resolver`, `ember-strict-resolver`, and any number of custom resolvers which exist in apps across the ecosystem. It has never had public documentation, but is fully public API. It is a user-constructible interface with the following definition (using the `Factory` and `FullName` types exported from the new `@ember/owner` module):
 
 ```ts
-import EmberObject from '@ember/object';
-import type { Factory, FullName } from '@ember/owner';
-
-type KnownForTypeResult<Name extends string> = {
+export type KnownForTypeResult<Name extends string> = {
   [fullName in `${Name}:${string}`]: boolean | undefined;
 };
 
-export interface Resolver extends EmberObject {
+export interface Resolver {
   knownForType?: <Name extends string>(type: Name) => KnownForTypeResult<Name>;
   lookupDescription?: (fullName: FullName) => string;
   makeToString?: (factory: Factory<object>, fullName: FullName) => string;
   normalize?: (fullName: FullName) => string;
   resolve(name: string): Factory<object> | object | undefined;
 }
+```
+
+The `KnownForTypeResult` utility type associated with it is also available as a named export. Unfortunately, due to currently limitations with TypeScript, you will generally have to *cast* to it, but it provides some type safety to callers, because it will *only* allow types corresponding to the passed string if users pass a string literal.
+
+Both are available as named, type-only, user-constructible interfaces from `@ember/owner`:
+
+```ts
+import { Resolver, KnownForTypeResult } from '@ember/owner';
 ```
 
 

--- a/text/0821-public-types.md
+++ b/text/0821-public-types.md
@@ -37,6 +37,7 @@ Introduce public import locations for type-only imports which have previously ha
     - [`getOwner` and `setOwner`](#getowner-and-setowner)
   - [`RouteInfo`](#routeinfo)
     - [`RouteInfoWithAttributes`](#routeinfowithattributes)
+  - [`Resolver`](#resolver)
 - [How we teach this](#how-we-teach-this)
   - [`Owner`](#owner-1)
   - [`Transition`, `RouteInfo`, and `RouteInfoWithAttributes`](#transition-routeinfo-and-routeinfowithattributes)
@@ -388,6 +389,28 @@ JS users can refer to it in JSDoc comments using `import()` syntax:
  */
 function takesRouteInfoWithAttributes(routeInfoWithAttributes) {
   // ...
+}
+```
+
+
+### `Resolver`
+
+The resolver is a contract implemented by libraries outside Ember itself, such as `ember-resolver`, `ember-strict-resolver`, and any number of custom resolvers which exist in apps across the ecosystem. It has never had public documentation, but is fully public API. It is a user-constructible interface with the following definition (using the `Factory` and `FullName` types exported from the new `@ember/owner` module), available as a new named type-only export from the `@ember/engine` package:
+
+```ts
+import EmberObject from '@ember/object';
+import type { Factory, FullName } from '@ember/owner';
+
+type KnownForTypeResult<Name extends string> = {
+  [fullName in `${Name}:${string}`]: boolean | undefined;
+};
+
+export interface Resolver extends EmberObject {
+  knownForType?: <Name extends string>(type: Name) => KnownForTypeResult<Name>;
+  lookupDescription?: (fullName: FullName) => string;
+  makeToString?: (factory: Factory<object>, fullName: FullName) => string;
+  normalize?: (fullName: FullName) => string;
+  resolve(name: string): Factory<object> | object | undefined;
 }
 ```
 


### PR DESCRIPTION
This was missed during the original work on [0821: Public API for Type-Only Imports](https://rfcs.emberjs.com/id/0821-public-types/), and caught while doing the work for emberjs/ember.js#20180. At last week’s Framework Core Team meeting, we agreed that it makes the most sense to add as an amendment to 821.

---

As a meta note, we expect to see this more often as we move to following [RFC 0617: RFC Stages](https://rfcs.emberjs.com/id/0617-rfc-stages). 0821 is currently *accepted* and will become *released* once we finish implementing it.