### PR TITLE
Update automation to fix spurious "more than one RFC added or modified"

### DIFF
--- a/.github/actions/find-added-or-modified-rfcs/action.yml
+++ b/.github/actions/find-added-or-modified-rfcs/action.yml
@@ -17,31 +17,20 @@ outputs:
     value: ${{ steps.modified-rfc.outputs.path }}
   modified-rfcs-count:
     description: "The count of how many RFCs were added or modified"
-    value: ${{ steps.counts.outputs.all_changed }}
+    value: ${{ steps.rfcs.outputs.all_changed_files_count }}
   added-rfcs-count:
     description: "The count of how many RFCs that were added"
-    value: ${{ steps.counts.outputs.added }}
+    value: ${{ steps.rfcs.outputs.added_files_count }}
 
 runs:
   using: "composite"
   steps:
     - name: Find added or modified RFCs
       id: rfcs
-      uses: tj-actions/changed-files@v31
+      uses: tj-actions/changed-files@v39
       with:
-        path: 'text'
-        json: 'true'
-        sha: ${{ inputs.sha }}
-        base_sha: ${{ inputs.base-sha }}
-
-    - name: Get counts of changed and added RFCs
-      id: counts
-      shell: bash
-      run: |
-        changed_len=`echo "${{ steps.rfcs.outputs.all_changed_files }}" | jq '. | length'`    
-        echo "all_changed=$changed_len" >> $GITHUB_OUTPUT
-        added_len=`echo "${{ steps.rfcs.outputs.added_files }}" | jq '. | length'`
-        echo "added=$added_len" >> $GITHUB_OUTPUT
+        files: text
+        json: true
 
     - name: Find modified or added RFC info
       id: modified-rfc

--- a/.github/workflows/advance-rfc.yml
+++ b/.github/workflows/advance-rfc.yml
@@ -26,8 +26,6 @@ jobs:
       - name: RFCs Added or Changed
         id: rfcs
         uses: ./.github/actions/find-added-or-modified-rfcs
-        with:
-          base-sha: ${{ github.event.before }}
 
       - name: Fail if more than 1 RFC is added or modified
         if: steps.rfcs.outputs.modified-rfcs-count > 1

--- a/.github/workflows/newly-added-rfcs.yml
+++ b/.github/workflows/newly-added-rfcs.yml
@@ -8,13 +8,6 @@ on:
     paths:
       - 'text/*.md'
 
-concurrency:
-  # Events within 5 minutes are not guaranteed to run in order, and so when removing S-Proposed and adding S-Exploring
-  # we can't guarantee that the run of the workflow will be the one where S-Exploring is added. Adding `github.event_name`
-  # to the concurrency allows both workflows to complete and the PR to eventually have successful checks.
-  group: newly-added-rfc-${{ github.head_ref || github.ref }}-${{ github.event_name }}
-  cancel-in-progress: true
-
 jobs:
   check-rfcs:
     name: Does PR add RFCs?
@@ -76,7 +69,7 @@ jobs:
       - name: Fail if more than 1 RFC is added or modified
         if: ${{ needs.check-rfcs.outputs.rfcs-changed > 1}}
         run: |
-          echo "::error::More than 1 RFC is added in this PR; will be unable to automatically open PRs for advancement"
+          echo "::error::More than 1 RFC is added or modified in this PR; will be unable to automatically open PRs for advancement"
           exit 1
 
   frontmatter-stage-is-accepted:

--- a/.github/workflows/open-advancement-pr.yml
+++ b/.github/workflows/open-advancement-pr.yml
@@ -61,7 +61,7 @@ jobs:
         uses: peter-evans/create-pull-request@v4.2.0
         with:
           token: ${{ secrets.personal-access-token }}
-          commit-message: "Advance RFC {{ inputs.rfc-number }} to Stage ${{ inputs.new-stage }}"
+          commit-message: "Advance RFC ${{ inputs.rfc-number }} to Stage ${{ inputs.new-stage }}"
           add-paths: 'text'
           branch: "advance-rfc-${{ inputs.rfc-number }}"
           title: "Advance RFC #${{ inputs.rfc-number}} `${{ steps.pr-variables.outputs.title }}` to Stage ${{ steps.pr-variables.outputs.pretty-stage }}"


### PR DESCRIPTION
- Fix an issue with interpolating RFC number in commits
- Remove concurrency for "Newly added RFCs" CI in an attempt to fix most times where github shows a check as incomplete when it did run

cc @runspired @jenweber 