### PR TITLE
Bugfix - date format on RFC 831

### DIFF
--- a/text/0831-standardize-use-npm-yarn.md
+++ b/text/0831-standardize-use-npm-yarn.md
@@ -1,6 +1,6 @@
 ---
 stage: accepted
-start-date: 2022-07-22
+start-date: 2022-07-22T00:00:00.000Z
 release-date: Unreleased
 release-versions:
 teams: # delete teams that aren't relevant


### PR DESCRIPTION
This needs to be ISO, or we see an error "Uncaught (in promise) RangeError: date value is not finite in DateTimeFormat.format()" in GitBook

Non-rendering page: https://rfcs.emberjs.com/id/0831-standardize-use-npm-yarn/