### PR TITLE
Make the `on` modifier built-in in strict-mode

### DIFF
--- a/text/0000-make-on-built-in.md
+++ b/text/0000-make-on-built-in.md
@@ -1,0 +1,84 @@
+---
+stage: accepted
+start-date: # In format YYYY-MM-DDT00:00:00.000Z
+release-date: # In format YYYY-MM-DDT00:00:00.000Z
+release-versions:
+teams: # delete teams that aren't relevant
+  - cli
+  - data
+  - framework
+  - learning
+  - steering
+  - typescript
+prs:
+  accepted: # Fill this in with the URL for the Proposal RFC PR
+project-link:
+suite: 
+---
+
+<!--- 
+Directions for above: 
+
+stage: Leave as is
+start-date: Fill in with today's date, 2032-12-01T00:00:00.000Z
+release-date: Leave as is
+release-versions: Leave as is
+teams: Include only the [team(s)](README.md#relevant-teams) for which this RFC applies
+prs:
+  accepted: Fill this in with the URL for the Proposal RFC PR
+project-link: Leave as is
+suite: Leave as is
+-->
+
+# <RFC title>
+
+## Summary
+
+> One paragraph explanation of the feature.
+
+## Motivation
+
+> Why are we doing this? What use cases does it support? What is the expected
+outcome?
+
+## Detailed design
+
+> This is the bulk of the RFC.
+
+> Explain the design in enough detail for somebody
+familiar with the framework to understand, and for somebody familiar with the
+implementation to implement. This should get into specifics and corner-cases,
+and include examples of how the feature is used. Any new terminology should be
+defined here.
+
+## How we teach this
+
+> What names and terminology work best for these concepts and why? How is this
+idea best presented? As a continuation of existing Ember patterns, or as a
+wholly new one?
+
+> Would the acceptance of this proposal mean the Ember guides must be
+re-organized or altered? Does it change how Ember is taught to new users
+at any level?
+
+> How should this feature be introduced and taught to existing Ember
+users?
+
+## Drawbacks
+
+> Why should we *not* do this? Please consider the impact on teaching Ember,
+on the integration of this feature with other existing and planned features,
+on the impact of the API churn on existing apps, etc.
+
+> There are tradeoffs to choosing any path, please attempt to identify them here.
+
+## Alternatives
+
+> What other designs have been considered? What is the impact of not doing this?
+
+> This section could also include prior art, that is, how other frameworks in the same domain have solved this problem.
+
+## Unresolved questions
+
+> Optional, but suggested for first drafts. What parts of the design are still
+TBD?

--- a/text/0997-make-on-built-in.md
+++ b/text/0997-make-on-built-in.md
@@ -108,6 +108,10 @@ This change would affect strict-mode only. This is so that today's existing code
 
 The behavior of `on` would be the same as it is today, but defined by default in the `glimmer-vm`.
 
+
+`on` will be a keyword, and for backwards compatibility, this will require that keywords, in strict mode, be overrideable by the strict-mode scope bag.
+
+
 ## How we teach this
 
 Once implemented, the guides, if they say anything about gjs/gts/`<template>` and `on` by the time this would be implemented, would only remove the import.
@@ -115,12 +119,15 @@ Once implemented, the guides, if they say anything about gjs/gts/`<template>` an
 ## Drawbacks
 
 People may not know where `on` is defined.
-- counterpoint: do they need to?
+- counterpoint: do they need to?, we are defining a lanugage, trying to make it ergonomic.
 
 ## Alternatives
 
-n/a
+- Use a prelude
+    - preludes were mentioned during the initial exploration of strict-mode templates, and were decided against, because addons would not be able to assume a prelude exists, as apps could define their own, and this sort of re-introduces the app-tree-merging behavior that we've been trying to get away from. 
+
 
 ## Unresolved questions
 
-n/a
+- What happens if we want to remove a keyword? (like `mut`)
+  - same as today, we only need to commit to a major to remove the keyword in and then do it - providing ample deprecation time, ending with the final removal.

--- a/text/0997-make-on-built-in.md
+++ b/text/0997-make-on-built-in.md
@@ -104,7 +104,7 @@ _Making `on` a built-in will help make writing components feel more cohesive and
 
 ## Detailed design
 
-This change would affect strict-mode only. This is so that today's existing code that imports `on` from `@ember/modifier` will still work due to how values define locally in scope override globals.
+This change would affect strict-mode only. This is so that today's existing code that imports `on` from `@ember/modifier` will still work due to how values defined locally in scope override globals.
 
 The behavior of `on` would be the same as it is today, but defined by default in the `glimmer-vm`.
 

--- a/text/0997-make-on-built-in.md
+++ b/text/0997-make-on-built-in.md
@@ -121,6 +121,8 @@ Once implemented, the guides, if they say anything about gjs/gts/`<template>` an
 People may not know where `on` is defined.
 - counterpoint: do they need to?, we are defining a lanugage, trying to make it ergonomic.
 
+We need to allow keywords to be overridable in Glimmer -- this is a behavior most languages do not allow.
+
 ## Alternatives
 
 - Use a prelude

--- a/text/0997-make-on-built-in.md
+++ b/text/0997-make-on-built-in.md
@@ -96,45 +96,31 @@ This strategy of always allowing local scope to override default-provided utilit
 
 </details>
 
+---------------
+
+_Making `on` a built-in will help make writing components feel more cohesive and well supported, as folks will not need to cobble together many imported values_
+
+----------------
 
 ## Detailed design
 
-> This is the bulk of the RFC.
+This change would affect strict-mode only. This is so that today's existing code that imports `on` from `@ember/modifier` will still work due to how values define locally in scope override globals.
 
-> Explain the design in enough detail for somebody
-familiar with the framework to understand, and for somebody familiar with the
-implementation to implement. This should get into specifics and corner-cases,
-and include examples of how the feature is used. Any new terminology should be
-defined here.
+The behavior of `on` would be the same as it is today, but defined by default in the `glimmer-vm`.
 
 ## How we teach this
 
-> What names and terminology work best for these concepts and why? How is this
-idea best presented? As a continuation of existing Ember patterns, or as a
-wholly new one?
-
-> Would the acceptance of this proposal mean the Ember guides must be
-re-organized or altered? Does it change how Ember is taught to new users
-at any level?
-
-> How should this feature be introduced and taught to existing Ember
-users?
+Once implemented, the guides, if they say anything about gjs/gts/`<template>` and `on` by the time this would be implemented, would only remove the import.
 
 ## Drawbacks
 
-> Why should we *not* do this? Please consider the impact on teaching Ember,
-on the integration of this feature with other existing and planned features,
-on the impact of the API churn on existing apps, etc.
-
-> There are tradeoffs to choosing any path, please attempt to identify them here.
+People may not know where `on` is defined.
+- counterpoint: do they need to?
 
 ## Alternatives
 
-> What other designs have been considered? What is the impact of not doing this?
-
-> This section could also include prior art, that is, how other frameworks in the same domain have solved this problem.
+n/a
 
 ## Unresolved questions
 
-> Optional, but suggested for first drafts. What parts of the design are still
-TBD?
+n/a

--- a/text/0997-make-on-built-in.md
+++ b/text/0997-make-on-built-in.md
@@ -126,6 +126,9 @@ People may not know where `on` is defined.
 - Use a prelude
     - preludes were mentioned during the initial exploration of strict-mode templates, and were decided against, because addons would not be able to assume a prelude exists, as apps could define their own, and this sort of re-introduces the app-tree-merging behavior that we've been trying to get away from. 
 
+- Use an alternate syntax: `on:click={{handler}}` or `on:{eventname}={{value}}`
+    - This would be even more ergonomic, and I think we should do this syntax anyway, but may take longer to implement. -- thought would not require glimmer allow the scope bag to overrid keywords.
+        
 
 ## Unresolved questions
 

--- a/text/0997-make-on-built-in.md
+++ b/text/0997-make-on-built-in.md
@@ -1,17 +1,14 @@
 ---
 stage: accepted
-start-date: # In format YYYY-MM-DDT00:00:00.000Z
+start-date: 2023-12-22T00:00:00.000Z
 release-date: # In format YYYY-MM-DDT00:00:00.000Z
 release-versions:
 teams: # delete teams that aren't relevant
-  - cli
-  - data
   - framework
   - learning
-  - steering
   - typescript
 prs:
-  accepted: # Fill this in with the URL for the Proposal RFC PR
+  accepted: https://github.com/emberjs/rfcs/pull/997
 project-link:
 suite: 
 ---
@@ -30,7 +27,7 @@ project-link: Leave as is
 suite: Leave as is
 -->
 
-# <RFC title>
+# Make `{{on}}` a built in modifier  
 
 ## Summary
 


### PR DESCRIPTION
# Propose making `{{on}}` a built in modifier

## [Rendered](https://github.com/NullVoxPopuli/rfcs/blob/make-on-built-in/text/0997-make-on-built-in.md)

## Summary

Today, we need
```js
import { on } from '@ember/modifier'`;
```

This should be built in, and not require an import.


---------------------------
---------------------------

**An FCP is required before merging this PR to advance to Accepted.**

Upon merging this PR, automation will open a draft PR for this RFC to move to the [Ready for Released Stage](https://github.com/emberjs/rfcs#ready-for-release).

<details>
  <summary>Exploring Stage Description</summary>

This stage is entered when the Ember team believes the concept described in the RFC should be pursued, but the RFC may still need some more work, discussion, answers to open questions, and/or a champion before it can move to the next stage.

An RFC is moved into Exploring with consensus of the relevant teams. The relevant team expects to spend time helping to refine the proposal. The RFC remains a PR and will have an `Exploring` label applied.

An Exploring RFC that is successfully completed can move to [Accepted](https://github.com/emberjs/rfcs#accepted) with an FCP is required as in the existing process. It may also be moved to [Closed](https://github.com/emberjs/rfcs#closed) with an FCP.
</details>

<details>
  <summary>Accepted Stage Description</summary>

To move into the "accepted stage" the RFC must have complete prose and have successfully passed through an "FCP to Accept" period in which the community has weighed in and consensus has been achieved on the direction. The relevant teams believe that the proposal is well-specified and ready for implementation. The RFC has a champion within one of the relevant teams.

If there are unanswered questions, we have outlined them and expect that they will be answered before [Ready for Release](https://github.com/emberjs/rfcs#ready-for-release). 

When the RFC is accepted, the PR will be merged, and automation will open a new PR to move the RFC to the [Ready for Release](https://github.com/emberjs/rfcs#ready-for-release) stage. That PR should be used to track implementation progress and gain consensus to move to the next stage.

</details>

## Checklist to move to Exploring

- [ ] The team believes the concepts described in the RFC should be pursued.
- [ ] The label `S-Proposed` is removed from the PR and the label `S-Exploring` is added. 
- [ ] The Ember team is willing to work on the proposal to get it to Accepted

## Checklist to move to Accepted

- [x] This PR has had the `Final Comment Period` label has been added to start the FCP
- [x] The RFC is announced in #news-and-announcements in the Ember Discord.
- [x] The RFC has complete prose, is well-specified and ready for implementation.
  - [x] All sections of the RFC are filled out.
  - [x] Any unanswered questions are outlined and expected to be answered before Ready for Release.
  - [x] "How we teach this?" is sufficiently filled out.
- [x] The RFC has a champion within one of the relevant teams.
- [x] The RFC has consensus after the FCP period.
