### PR TITLE
Deprecate named `inject` export from `@ember/service`

### DIFF
--- a/text/1001-deprecate-named-inject.md
+++ b/text/1001-deprecate-named-inject.md
@@ -1,17 +1,13 @@
 ---
 stage: accepted
-start-date:
+start-date: 2023-12-26T00:00:00.000Z
 release-date:
 release-versions:
 teams: # delete teams that aren't relevant
-  - cli
-  - data
   - framework
-  - learning
-  - steering
   - typescript
 prs:
-  accepted: # update this to the PR that you propose your RFC in
+  accepted: https://github.com/emberjs/rfcs/pull/1001
 project-link:
 ---
 

--- a/text/1001-deprecate-named-inject.md
+++ b/text/1001-deprecate-named-inject.md
@@ -1,0 +1,64 @@
+---
+stage: accepted
+start-date:
+release-date:
+release-versions:
+teams: # delete teams that aren't relevant
+  - cli
+  - data
+  - framework
+  - learning
+  - steering
+  - typescript
+prs:
+  accepted: # update this to the PR that you propose your RFC in
+project-link:
+---
+
+<!---
+Directions for above:
+
+stage: Leave as is
+start-date: Fill in with today's date, 2032-12-01T00:00:00.000Z
+release-date: Leave as is
+release-versions: Leave as is
+teams: Include only the [team(s)](README.md#relevant-teams) for which this RFC applies
+prs:
+  accepted: Fill this in with the URL for the Proposal RFC PR
+project-link: Leave as is
+-->
+
+# Deprecate named inject 
+
+## Summary
+
+As of `ember-source@4.1` (and [RFC#752](https://github.com/emberjs/rfcs/pull/752)),  `inject` is an old alias that's no longer needed
+
+## Motivation
+
+`import { service } from '@ember/service'`
+makes more sense than 
+`import { inject as service } from '@ember/service'`
+
+This allows us to slim down our public API surface area to more of _what's needed_.
+
+
+## Transition Path
+
+Most folks can do a mass find and replace switch from `inject as service` to just `service`.
+
+## How We Teach This
+
+The docs / guides already use the new import path.
+
+## Drawbacks
+
+n/a
+
+## Alternatives
+
+n/a
+
+## Unresolved questions
+
+n/a

--- a/text/1001-deprecate-named-inject.md
+++ b/text/1001-deprecate-named-inject.md
@@ -176,7 +176,10 @@ n/a
 
 ## Alternatives
 
-n/a
+do nothing, the cost of an export alias is:
+- a few extra bytes
+- mental gymnastics for teaching
+- "another case to cover" for tooling
 
 ## Unresolved questions
 

--- a/text/1001-deprecate-named-inject.md
+++ b/text/1001-deprecate-named-inject.md
@@ -24,7 +24,7 @@ prs:
 project-link: Leave as is
 -->
 
-# Deprecate named inject 
+# Deprecate named `inject` export from `@ember/service`
 
 ## Summary
 

--- a/text/1001-deprecate-named-inject.md
+++ b/text/1001-deprecate-named-inject.md
@@ -28,7 +28,7 @@ project-link: Leave as is
 
 ## Summary
 
-As of `ember-source@4.1` (and [RFC#752](https://github.com/emberjs/rfcs/pull/752)),  `inject` is an old alias that's no longer needed
+As of [`ember-source@4.1`](https://blog.emberjs.com/ember-4-1-released) (and [RFC#752](https://github.com/emberjs/rfcs/pull/752)),  `inject` is an old alias that's no longer needed
 
 ## Motivation
 

--- a/text/1001-deprecate-named-inject.md
+++ b/text/1001-deprecate-named-inject.md
@@ -43,6 +43,129 @@ This allows us to slim down our public API surface area to more of _what's neede
 
 Most folks can do a mass find and replace switch from `inject as service` to just `service`.
 
+An example codemod could look [something like this](https://astexplorer.net/#/gist/119f88339ea024e7cde63c71f52ce216/4d128a1239cbb56e00a69d3f710d67c20ed0e431)
+```js 
+export const parser = 'ts'
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  
+  const importNames = new Set();
+
+  const root = j(file.source);
+  
+  // find things we want to get rid of
+  root
+    .find(j.ImportSpecifier)
+    .forEach(path => {
+      if (path.node.imported.name === 'inject') {
+      	importNames.add(path.node.local.name);
+      }
+    })
+  
+  // now it's time to replace
+  root.find(j.ClassProperty).forEach(path => {
+    let node = path.node;
+    
+    let hasInject = hasDecorators(node, [...importNames.values()]);
+    
+    if (!hasInject) return;
+    
+    node.decorators = node.decorators.map(decorator => {
+      let { expression } = decorator;
+      
+      if (expression.type === 'Identifier') {
+        if (importNames.has(expression.name)) {
+          decorator.expression = j.identifier('service');
+        }
+      }
+      
+      if (expression.type === 'CallExpression') {
+        decorator.expression.callee = j.identifier('service');
+      }
+      
+      return decorator;
+    });
+  });
+  
+  return root.toSource();
+}
+
+// Copied from: https://github.com/NullVoxPopuli/ember-concurrency-codemods/tree/main
+function firstMatchingDecorator(node, named = []) {
+  if (!node.decorators) return;
+
+  return node.decorators.find((decorator) => {
+    let { expression } = decorator;
+
+    switch (expression.type) {
+      case 'MethodDefinition': {
+      }
+      case 'CallExpression': {
+        let { callee } = expression;
+
+        switch (callee.type) {
+          case 'Identifier':
+            return named.includes(callee.name);
+          case 'MemberExpression': {
+            let { object } = callee;
+
+            return named.includes(object.callee.name);
+          }
+        }
+      }
+      case 'Identifier':
+        return named.includes(expression.name);
+    }
+  });
+}
+
+function hasDecorators(node, named = []) {
+  return Boolean(firstMatchingDecorator(node, named));
+}
+```
+
+<details><summary>The test scenarios</summary>
+
+```ts 
+import { inject } from '@ember/service';
+import { inject as service } from '@ember/service';
+// import Service from '@ember/service';
+import BaseService from '@ember/service';
+import { inject as serviceDecorator } from '@ember/service';
+import { inject as x } from '@ember/service';
+// import { service } from '@ember/service';
+import { service as y } from '@ember/service';
+// import Service, { inject, service } from '@ember/service';
+import Service, { inject as s } from '@ember/service';
+
+
+export default class Demo extends Service {
+  
+}
+
+export default class Demo2 extends BaseService {
+  // simple
+  @inject router;
+  @service router1;
+  @x router2;
+  @y router3;
+  @serviceDecorator router4;
+  @inject('router') router41;
+  
+  // TS-only
+  @inject declare router5: Type;
+  @inject('router') declare router51: Type;
+  @service declare router6: Type;
+  @x declare router7: Type;
+  @y declare router8: Type;
+  @serviceDecorator declare router9: Type;
+}
+```
+
+</detailS>
+
+
 ## How We Teach This
 
 The docs / guides already use the new import path.

--- a/text/1001-deprecate-named-inject.md
+++ b/text/1001-deprecate-named-inject.md
@@ -172,7 +172,9 @@ The docs / guides already use the new import path.
 
 ## Drawbacks
 
-n/a
+As with any deprecation, we introduce an upgrade cliff for addons that are updated infrequently, and consequently their consuming apps.
+As a mitigation, we could, for v1 addons, add an additional transform to ember-cli-babel to automatically upgrade `inject` from `@ember/service` to `service`.
+This does narrow the range a bit, as `service` was introduced in ember-source@4.1, so libraries could not support from 3.28 to 6 (or whichever major ends up removing the `inject`) without adding `@embroider/macros` to conditionally import `inject` or `service` based on the consumer's ember-source version.
 
 ## Alternatives
 
@@ -180,6 +182,9 @@ do nothing, the cost of an export alias is:
 - a few extra bytes
 - mental gymnastics for teaching
 - "another case to cover" for tooling
+
+add a lint against `inject`
+- all the downsides of the above ("do nothing") may still be present
 
 ## Unresolved questions
 


### PR DESCRIPTION
<!-- If you are proposing a new RFC, please fill out the below template. 
If not, please remove the below contents
-->

# Propose deprecating named `inject`

<!-- Update the below to link to the rendered version of your RFC. 
The URL can be interpolated below or can be found by going to the files tab
and choosing `View file' from the `...' menu in the right hand corner of the file. -->

## [Rendered](https://github.com/emberjs/rfcs/blob/deprecate-named-inject/text/1001-deprecate-named-inject.md)

## Summary

This pull request is proposing a new RFC.

To succeed, it will need to pass into the [Exploring Stage](https://github.com/emberjs/rfcs#exploring)), followed by the [Accepted Stage](https://github.com/emberjs/rfcs#accepted).

A Proposed or Exploring RFC may also move to the [Closed Stage](https://github.com/emberjs/rfcs#closed) if it is withdrawn by the author or if it is rejected by the Ember team. This requires an "FCP to Close" period.

**An FCP is required before merging this PR to advance to Accepted.**

Upon merging this PR, automation will open a draft PR for this RFC to move to the [Ready for Released Stage](https://github.com/emberjs/rfcs#ready-for-release).

<details>
  <summary>Exploring Stage Description</summary>

This stage is entered when the Ember team believes the concept described in the RFC should be pursued, but the RFC may still need some more work, discussion, answers to open questions, and/or a champion before it can move to the next stage.

An RFC is moved into Exploring with consensus of the relevant teams. The relevant team expects to spend time helping to refine the proposal. The RFC remains a PR and will have an `Exploring` label applied.

An Exploring RFC that is successfully completed can move to [Accepted](https://github.com/emberjs/rfcs#accepted) with an FCP is required as in the existing process. It may also be moved to [Closed](https://github.com/emberjs/rfcs#closed) with an FCP.
</details>

<details>
  <summary>Accepted Stage Description</summary>

To move into the "accepted stage" the RFC must have complete prose and have successfully passed through an "FCP to Accept" period in which the community has weighed in and consensus has been achieved on the direction. The relevant teams believe that the proposal is well-specified and ready for implementation. The RFC has a champion within one of the relevant teams.

If there are unanswered questions, we have outlined them and expect that they will be answered before [Ready for Release](https://github.com/emberjs/rfcs#ready-for-release). 

When the RFC is accepted, the PR will be merged, and automation will open a new PR to move the RFC to the [Ready for Release](https://github.com/emberjs/rfcs#ready-for-release) stage. That PR should be used to track implementation progress and gain consensus to move to the next stage.

</details>

## Checklist to move to Exploring

- [ ] The team believes the concepts described in the RFC should be pursued.
- [ ] The label `S-Proposed` is removed from the PR and the label `S-Exploring` is added. 
- [ ] The Ember team is willing to work on the proposal to get it to Accepted

## Checklist to move to Accepted

- [x] This PR has had the `Final Comment Period` label has been added to start the FCP
- [x] The RFC is announced in #news-and-announcements in the Ember Discord.
- [ ] The RFC has complete prose, is well-specified and ready for implementation.
  - [ ] All sections of the RFC are filled out.
  - [ ] Any unanswered questions are outlined and expected to be answered before Ready for Release.
  - [ ] "How we teach this?" is sufficiently filled out.
- [ ] The RFC has a champion within one of the relevant teams.
- [ ] The RFC has consensus after the FCP period.
