### PR TITLE
Deprecate the (action) template helper and modifier

### DIFF
--- a/text/1005-deprecate-action-template-helper.md
+++ b/text/1005-deprecate-action-template-helper.md
@@ -1,0 +1,126 @@
+---
+stage: accepted
+start-date: 2024-02-13T00:00:00.000Z
+release-date:
+release-versions:
+teams: # delete teams that aren't relevant
+  - cli
+  - data
+  - framework
+  - learning
+  - steering
+  - typescript
+prs:
+  accepted: # update this to the PR that you propose your RFC in
+project-link:
+---
+
+<!---
+Directions for above:
+
+stage: Leave as is
+start-date: Fill in with today's date, 2032-12-01T00:00:00.000Z
+release-date: Leave as is
+release-versions: Leave as is
+teams: Include only the [team(s)](README.md#relevant-teams) for which this RFC applies
+prs:
+  accepted: Fill this in with the URL for the Proposal RFC PR
+project-link: Leave as is
+-->
+
+# Deprecate `(action)` template helper 
+
+## Summary
+
+The `(action)` template helper was common pre-Octane. Now that we have native classes and the `{{on}}` modifier, we no longer need to use `(action)` 
+
+## Motivation
+
+Remove legacy code with confusing semantics.
+
+## Transition Path
+
+This was written in the [Octave vs Classic cheatsheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__ddau)
+
+That content here:
+
+### Before (pre-Octane)
+
+```js
+// parent-component.js
+import Component from '@ember/component';
+
+export default Component.extend({
+  count: 0
+});
+
+```
+```hbs
+{{!-- parent-component.hbs --}}
+{{child-component count=count}}
+Count: {{this.count}}
+
+```
+```js
+// child-component.js
+import Component from '@ember/component';
+
+export default Component.extend({
+  actions: {
+    plusOne() {
+      this.set('count', this.get('count') + 1);
+    }
+  }
+});
+```
+```hbs
+{{!-- child-component.hbs --}}
+<button type="button" {{action "plusOne"}}>
+  Click Me
+</button>
+```
+
+### After (post-Octane)
+```js
+// parent-component.js
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class ParentComponent extends Component {
+  @tracked count = 0;
+
+  @action plusOne() {
+    this.count++;
+  }
+}
+
+```
+```hbs
+{{!-- parent-component.hbs --}}
+<ChildComponent @plusOne={{this.plusOne}} />
+Count: {{this.count}}
+
+```
+```hbs
+{{!-- child-component.hbs --}}
+<button type="button" {{on "click" @plusOne}}>
+  Click Me
+</button>
+
+```
+
+## How We Teach This
+
+The guides already cover how to invoke functions in the modern way.
+
+Remove: https://api.emberjs.com/ember/5.6/classes/Ember.Templates.helpers/methods/action?anchor=action
+
+## Drawbacks
+
+Older code will stop working once the deprecated code is removed.
+
+## Alternatives
+
+## Unresolved questions
+

--- a/text/1006-deprecate-action-template-helper.md
+++ b/text/1006-deprecate-action-template-helper.md
@@ -229,8 +229,14 @@ Before:
 After:
 ```js
 // parent.js
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
 export default class SomeComponent extends Component {
-    handleUpdate = (value) => this.args.property = value; 
+    @action
+    handleUpdate(value) {
+        this.args.property = value; 
+    }
 }
 ```
 ```hbs

--- a/text/1006-deprecate-action-template-helper.md
+++ b/text/1006-deprecate-action-template-helper.md
@@ -224,7 +224,7 @@ After:
 
 Before:
 ```hbs
-<SomeComponent @update={{action (mut @value.property}} />
+<SomeComponent @update={{action (mut @value.property)}} />
 ```
 After:
 ```js

--- a/text/1006-deprecate-action-template-helper.md
+++ b/text/1006-deprecate-action-template-helper.md
@@ -139,6 +139,62 @@ or, if `plusOne` is passed in as an argument
 </button>
 ```
 
+If the `plusOne` action is in an actions object, it needs to move out:
+
+Before:
+```js
+import Component from '@glimmer/component';
+
+export default class Demo extends Component {
+    actions = {
+        plusOne() {
+           /* ... */ 
+        }
+    }
+}
+```
+or
+```js
+import Component from '@ember/component';
+
+export default class Demo extends Component {
+    actions = {
+        plusOne() {
+           /* ... */ 
+        }
+    }
+}
+```
+or
+```js
+import Component from '@ember/component';
+
+export default Component.extend({
+    actions: {
+        plusOne() {
+           /* ... */ 
+        }
+    }
+})
+```
+
+After:
+```js
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class Demo extends Component {
+    @action
+    plusOne() {
+       /* ... */ 
+    }
+}
+```
+
+Note that `@action` is completely different from `(action)` or `{{action}}` (and is partly a motivator for deprecating `(action)` and `{{action}}`, to reduce ambiguity).
+
+`@action` is binds the `this` on the method to the instance of the class. 
+
 ### Scenario: `action` is passed a function reference
 
 Before:

--- a/text/1006-deprecate-action-template-helper.md
+++ b/text/1006-deprecate-action-template-helper.md
@@ -244,6 +244,11 @@ export default class SomeComponent extends Component {
 <SomeComponent @update={{this.handleUpdate}} />
 ```
 
+Related, [Combining function arguments with action functions](https://guides.emberjs.com/release/components/component-state-and-actions/#toc_combining-arguments-and-actions)
+
+### Related: `send`
+
+When removing `(action)` or `{{action}}` with a _string_ name, you'll also need to verify that there are no [`send`](https://api.emberjs.com/ember/5.6/classes/Component/methods/send?anchor=send) calls with that same string.
 
 ## How We Teach This
 

--- a/text/1006-deprecate-action-template-helper.md
+++ b/text/1006-deprecate-action-template-helper.md
@@ -11,7 +11,7 @@ teams: # delete teams that aren't relevant
   - steering
   - typescript
 prs:
-  accepted: # update this to the PR that you propose your RFC in
+  accepted: https://github.com/emberjs/rfcs/pull/1006
 project-link:
 ---
 

--- a/text/1006-deprecate-action-template-helper.md
+++ b/text/1006-deprecate-action-template-helper.md
@@ -28,11 +28,11 @@ prs:
 project-link: Leave as is
 -->
 
-# Deprecate `(action)` template helper 
+# Deprecate `(action)` template helper and `{{action}}` modifier. 
 
 ## Summary
 
-The `(action)` template helper was common pre-Octane. Now that we have native classes and the `{{on}}` modifier, we no longer need to use `(action)` 
+The `(action)` template helper and `{{action}}` modifier was common pre-Octane. Now that we have native classes and the `{{on}}` modifier, we no longer need to use `(action)` or `{{action}}`
 
 ## Motivation
 
@@ -42,7 +42,7 @@ Remove legacy code with confusing semantics.
 
 This was written in the [Octave vs Classic cheatsheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__ddau)
 
-That content here:
+<details><summary>that content here</summary>
 
 ### Before (pre-Octane)
 
@@ -110,6 +110,77 @@ Count: {{this.count}}
 
 ```
 
+</details>
+
+But what we could put in the deprecation app:
+
+### Scenario: `action` is passed a string
+
+Before:
+```hbs
+<button type="button" {{action "plusOne"}}>
+  Click Me
+</button>
+```
+
+After
+
+```hbs
+<button type="button" {{on 'click' this.plusOne}}>
+  Click Me
+</button>
+```
+or, if `plusOne` is passed in as an argument 
+```hbs
+<button type="button" {{on 'click' @plusOne}}>
+  Click Me
+</button>
+```
+
+### Scenario: `action` is passed a function reference
+
+Before:
+```hbs
+<SomeComponent @update={{action this.plusOne}} />
+```
+
+After
+
+```hbs
+<SomeComponent @update={{this.plusOne}} />
+```
+
+### Scenario: `action` is passed parameters
+
+Before:
+```hbs
+<SomeComponent @update={{action this.plus 1}} />
+```
+
+After:
+```hbs
+<SomeComponent @update={{fn this.plus 1}} />
+```
+
+### Scenario: `action` is used with `mut` 
+
+Before:
+```hbs
+<SomeComponent @update={{action (mut @value.property}} />
+```
+After:
+```js
+// parent.js
+export default class SomeComponent extends Component {
+    handleUpdate = (value) => this.args.property = value; 
+}
+```
+```hbs
+{{! parent.hbs }}
+<SomeComponent @update={{this.handleUpdate}} />
+```
+
+
 ## How We Teach This
 
 The guides already cover how to invoke functions in the modern way.
@@ -122,5 +193,11 @@ Older code will stop working once the deprecated code is removed.
 
 ## Alternatives
 
+- adding an import so folks can keep using action in gjs.
+  I don't think we should do this because we want to clean up antiquated patterns, rather than encourage their continued existence.
+
 ## Unresolved questions
+
+- Could there be a codemod?
+  _Potentially_ for action usage that references `this.properties`. For string actions, it's impossible.
 

--- a/text/1006-deprecate-action-template-helper.md
+++ b/text/1006-deprecate-action-template-helper.md
@@ -38,6 +38,8 @@ The `(action)` template helper and `{{action}}` modifier was common pre-Octane. 
 
 Remove legacy code with confusing semantics.
 
+This is a part of _[Deprecating Ember Classic (pre-Octane)](https://github.com/emberjs/rfcs/issues/832)_.
+
 ## Transition Path
 
 This was written in the [Octave vs Classic cheatsheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/#component-properties__ddau)


### PR DESCRIPTION
<!-- If you are proposing a new RFC, please fill out the below template. 
If not, please remove the below contents
-->

# Propose deprecating the `(action)` template helper and modifier

<!-- Update the below to link to the rendered version of your RFC. 
The URL can be interpolated below or can be found by going to the files tab
and choosing `View file' from the `...' menu in the right hand corner of the file. -->

## [Rendered](https://github.com/emberjs/rfcs/blob/deprecate-action-template-helper/text/1006-deprecate-action-template-helper.md)

## Summary

This pull request is proposing a new RFC.

To succeed, it will need to pass into the [Exploring Stage](https://github.com/emberjs/rfcs#exploring)), followed by the [Accepted Stage](https://github.com/emberjs/rfcs#accepted).

A Proposed or Exploring RFC may also move to the [Closed Stage](https://github.com/emberjs/rfcs#closed) if it is withdrawn by the author or if it is rejected by the Ember team. This requires an "FCP to Close" period.

**An FCP is required before merging this PR to advance to Accepted.**

Upon merging this PR, automation will open a draft PR for this RFC to move to the [Ready for Released Stage](https://github.com/emberjs/rfcs#ready-for-release).

<details>
  <summary>Exploring Stage Description</summary>

This stage is entered when the Ember team believes the concept described in the RFC should be pursued, but the RFC may still need some more work, discussion, answers to open questions, and/or a champion before it can move to the next stage.

An RFC is moved into Exploring with consensus of the relevant teams. The relevant team expects to spend time helping to refine the proposal. The RFC remains a PR and will have an `Exploring` label applied.

An Exploring RFC that is successfully completed can move to [Accepted](https://github.com/emberjs/rfcs#accepted) with an FCP is required as in the existing process. It may also be moved to [Closed](https://github.com/emberjs/rfcs#closed) with an FCP.
</details>

<details>
  <summary>Accepted Stage Description</summary>

To move into the "accepted stage" the RFC must have complete prose and have successfully passed through an "FCP to Accept" period in which the community has weighed in and consensus has been achieved on the direction. The relevant teams believe that the proposal is well-specified and ready for implementation. The RFC has a champion within one of the relevant teams.

If there are unanswered questions, we have outlined them and expect that they will be answered before [Ready for Release](https://github.com/emberjs/rfcs#ready-for-release). 

When the RFC is accepted, the PR will be merged, and automation will open a new PR to move the RFC to the [Ready for Release](https://github.com/emberjs/rfcs#ready-for-release) stage. That PR should be used to track implementation progress and gain consensus to move to the next stage.

</details>

## Checklist to move to Exploring

- [ ] The team believes the concepts described in the RFC should be pursued.
- [ ] The label `S-Proposed` is removed from the PR and the label `S-Exploring` is added. 
- [ ] The Ember team is willing to work on the proposal to get it to Accepted

## Checklist to move to Accepted

- [x] This PR has had the `Final Comment Period` label has been added to start the FCP
- [ ] The RFC is announced in #news-and-announcements in the Ember Discord.
- [ ] The RFC has complete prose, is well-specified and ready for implementation.
  - [ ] All sections of the RFC are filled out.
  - [ ] Any unanswered questions are outlined and expected to be answered before Ready for Release.
  - [ ] "How we teach this?" is sufficiently filled out.
- [ ] The RFC has a champion within one of the relevant teams.
- [ ] The RFC has consensus after the FCP period.
