### PR TITLE
External default blueprints in ember-cli

### DIFF
--- a/text/0000-external-blueprints-by-default.md
+++ b/text/0000-external-blueprints-by-default.md
@@ -1,0 +1,205 @@
+---
+stage: accepted
+start-date: 2024-11-30T00:00:00.000Z
+release-date: # In format YYYY-MM-DDT00:00:00.000Z
+release-versions:
+teams: # delete teams that aren't relevant
+  - cli
+  - framework
+  - learning
+prs:
+  accepted: # Fill this in with the URL for the Proposal RFC PR
+project-link:
+suite: 
+---
+
+<!--- 
+Directions for above: 
+
+stage: Leave as is
+start-date: Fill in with today's date, 2032-12-01T00:00:00.000Z
+release-date: Leave as is
+release-versions: Leave as is
+teams: Include only the [team(s)](README.md#relevant-teams) for which this RFC applies
+prs:
+  accepted: Fill this in with the URL for the Proposal RFC PR
+project-link: Leave as is
+suite: Leave as is
+-->
+
+# external default blueprints in ember-cli 
+
+## Summary
+
+External blueprints give us the ability to rapidly iterate and distribute changes to the blueprint. They allow us to release changes at a pace that is more frequent than the release train. This decoupling is highly desirable, and doesn't diminish the purpose and goals of the release train process. 
+
+## Motivation
+
+Since we're wanting to introduce new blueprints, for both the [v2 app][gh-v2-app-blueprint] and [v2 addon][gh-v2-addon-blueprint], as default, we need to quickly iterate and release updates. The release-train that ember-cli abides by is useful to protect users from any instability that may occur during active development. However, since blueprints are always opt in -- either via new project, or updating an old project, it is safe to for blueprints to have separate release cadences from the core ember-cli project. 
+
+
+[gh-v2-app-blueprint]: https://github.com/embroider-build/app-blueprint
+[gh-v2-addon-blueprint]: https://github.com/embroider-build/addon-blueprint
+[rfc-v2-app-blueprint]: https://github.com/emberjs/rfcs/pull/977
+[rfc-v2-addon-blueprint]: https://github.com/emberjs/rfcs/pull/985 
+
+## Detailed design
+
+**tl;dr, behavior changes**
+1. external blueprints are added to `dependencies` of `ember-cli`. Default behavior uses the resolved path from `depndencies`
+2. ember-cli will prompt the user if they wish to use the latest version of the blueprint if one is available 
+3. ember-cli always prints which blueprint it is using and from where
+4. ember-cli will not print warnings on custom flags used in blueprints
+
+**tl;dr: for external blueprints**
+1. same node support as ember-cli 
+2. must (also) test against windows
+3. if the blueprint generates a project, every package.json#script must be tested and exit with status 0 (success).
+
+**tl;dr, non-behavior changes**
+1. this RFC does not change any of the current blueprints (other RFCs may, (such as for the [v2 app][rfc-v2-app-blueprint] and the [v2 addon][rfc-v2-addon-blueprint]))
+2. this RFC does not suggest we change anything about how ember-cli releases
+
+
+The main thing to retain with external blueprints is the output of a blueprint must be the same for all of time when a version of ember-cli is released. This is, in part, to help the upgrade story for folks batching many versions of upgrades at once, so they have roughly the same experience as folks who upgrade their apps as updates are released.
+
+To solve this, ember-cli would want to use specific versions of blueprints for each release. These can be managed via `dependencies` and without a range character (`~`, `^`, etc). The `--blueprint` argument already accepts a path, and we can configure `dirname(require.resolve('blueprint-name')` to pass to `--blueprint`.
+
+While pinning would ensure long-term repeatability, it does mean that we accidentally lose one of the benefits of external blueprints -- frequent updates. With the release-train that ember-cli uses, with no further changes -- and including for all blueprints prior -- users must wait **¼ year**, best case scenario, from time of PR to release of ember-cli, before blueprint updates may be adopted via using the stable release of ember-cli.  
+
+To resolve, ember-cli will query, if there is an internet connection, what the latest version of the external blueprint is, and if it is newer than the current bundled (defined in `dependencies`) version: the user will be prompted if they want to use the bundled version of the blueprint or the latest version. 
+
+For [example][example-ember-clack-external-blueprints]:
+```
+┌   ember new 
+│
+◆  There is a newer version of `@embroider/app-blueprint` available. Would you like to use it?
+│  ● 2.0.1 (default)
+│  ○ 3.4.19 (latest)
+└
+```
+
+Since there is a possibility of ember-cli using different versions, we need to show which version and at what path is of the blueprint.
+
+For [example][example-ember-clack-external-blueprints]:
+```
+┌   ember new 
+│
+●  Using blueprint from /home/projects/clack-prompts/node_modules/@embroider/app-blueprint
+│
+```
+or 
+``` 
+┌   ember new 
+│
+◇  There is a newer version of `@embroider/app-blueprint` available. Would you like to use it?
+│  3.4.19 (latest)
+│
+●  Using blueprint from /tmp/abc123/hash/@embroider/app-blueprint
+│
+│
+◇  Installed via npm
+│
+```
+
+The exact details of the prompts here fall under implementation detail, and are not prescribed by this RFC.
+
+[example-ember-clack-external-blueprints]: https://stackblitz.com/edit/clack-prompts-gg5p7c?file=package.json
+
+### Upgrade paths 
+
+In order for upgrades to be smooth for external blueprints, blueprints need to be able to "feature detect" the situations, environment, and capabilities of the project that an upgrade is being applied to. For the existing blueprint system, it means that ember-cli will need to allow blueprints to have any custom flags they blueprint deems necessary. For example, in the `@embroider/app-blueprint`, it will want to detect, upon upgrade, if `hbs` support is needed, and may represent that as `--hbs-support=true|false`, which would become available via the blueprint `options` object passed around to all the blueprint function hooks. So feature detection needs to occur _before_ the options object is built. This would be an addition to ember-cli's blueprint system, we can call it `detectFeatures()`, which returns a Promise which resolves to an object, which would be spread in to the `options` object, allowing the features to be configured in the blueprint's `locals`, which allows the blueprint-diff infrastructure to appropriately upgrade the app. 
+
+Example:
+
+```js 
+// my-blueprint/index.js (CommonJS)
+'use strict';
+
+const { getFeatures } = require('ember-cli/lib/blueprint-utils');
+const path = require('path');
+const globSync = require('....');
+
+
+module.exports = {
+    /**
+     * Called during `init` (used when upgrading)
+     * Skipped during `new` and `addon` (nothing to detect)
+     *
+     * @param {string} targetDirectory the directory that the blueprint is running in (the app to upgrade)
+     */
+    async detectFeatures(targetDirectory) {
+        return {
+            hbs: globSync('**/*.hbs', { cwd: targetDirectory }).length > 0,
+            typescript: pathExists(path.join(targetDirectory, 'tsconfig.json')), 
+        }
+    },
+
+    locals(options) {
+        let features = getFeatures(options) ?? { 
+            /* default for new / addon */ 
+            hbs: true, 
+            typescript: false,
+        };
+
+        return {
+            name,
+            /* ... */
+            features,
+        }
+    }
+}
+```
+
+and then in the `vite.config.mjs`:
+```js 
+import {
+  // ...
+<% if (features.hbs) { %>
+    hbs,
+<% } %>
+  // ...
+} from '@embroider/vite';
+
+// ...
+export default defineConfig(({ mode }) => {
+    return {
+        plugins: [
+        <% if (features.hbs) { %>
+          hbs(),
+        <% } %>
+        }
+        // ...
+    }
+```
+
+### Prerequisites for an external blueprint to become default 
+
+Note that these do not, nor should not, precede the planning / RFC work for proposing an external blueprint to become default (as to not block future or presently in-progress RFCs).
+
+An External Blueprint needs to:
+1. have its CI run against the same node support range as ember-cli.
+2. be able to run all its tests against Windows  
+3. Adhere to SemVer
+4. If the external blueprint generates a project, there should be a set of "slow" / acceptance tests that assure that all package.json#scripts can succeed.
+
+## How we teach this
+
+The terminal output and guidance should be enough for most users.
+
+For blueprint authors, this RFC defines the prerequisites for using an external blueprint as default in ember-cli. 
+
+## Drawbacks
+
+- more code in ember-cli
+- no release-train for blueprints
+
+## Alternatives
+
+- do nothing (likely continued friction between ember-cli releases and blueprint development)
+- unpinned blueprints in ember-cli releases (or `~` ranges in `dependencies`)
+- no interactive prompt to use latest (would make it harder for users to know there may be potential bugfixes)
+
+## Unresolved questions
+
+none yet

--- a/text/1054-external-blueprints-by-default.md
+++ b/text/1054-external-blueprints-by-default.md
@@ -46,7 +46,7 @@ Since we're wanting to introduce new blueprints, for both the [v2 app][gh-v2-app
 ## Detailed design
 
 **tl;dr, behavior changes**
-1. external blueprints are added to `dependencies` of `ember-cli`. Default behavior uses the resolved path from `depndencies`
+1. external blueprints are added to `dependencies` of `ember-cli`. Default behavior uses the resolved path from `dependencies`
 2. ember-cli will prompt the user if they wish to use the latest version of the blueprint if one is available 
 3. ember-cli always prints which blueprint it is using and from where
 4. ember-cli will not print warnings on custom flags used in blueprints

--- a/text/1054-external-blueprints-by-default.md
+++ b/text/1054-external-blueprints-by-default.md
@@ -3,12 +3,12 @@ stage: accepted
 start-date: 2024-11-30T00:00:00.000Z
 release-date: # In format YYYY-MM-DDT00:00:00.000Z
 release-versions:
-teams: # delete teams that aren't relevant
+teams: 
   - cli
   - framework
   - learning
 prs:
-  accepted: # Fill this in with the URL for the Proposal RFC PR
+  accepted: https://github.com/emberjs/rfcs/pull/1054
 project-link:
 suite: 
 ---


### PR DESCRIPTION
<!-- If you are proposing a new RFC, please fill out the below template. 
If not, please remove the below contents
-->

# Propose supporting external default blueprints in ember-cli

<!-- Update the below to link to the rendered version of your RFC. 
The URL can be interpolated below or can be found by going to the files tab
and choosing `View file' from the `...' menu in the right hand corner of the file. -->

## [Rendered](https://github.com/emberjs/rfcs/blob/ember-cli-divests-blueprints/text/1054-external-blueprints-by-default.md)

Some motivation over in this repo: https://github.com/embroider-build/app-blueprint/pull/121



## Summary

This pull request is proposing a new RFC.

To succeed, it will need to pass into the [Exploring Stage](https://github.com/emberjs/rfcs#exploring), followed by the [Accepted Stage](https://github.com/emberjs/rfcs#accepted).

A Proposed or Exploring RFC may also move to the [Closed Stage](https://github.com/emberjs/rfcs#closed) if it is withdrawn by the author or if it is rejected by the Ember team. This requires an "FCP to Close" period.

**An FCP is required before merging this PR to advance to Accepted.**

Upon merging this PR, automation will open a draft PR for this RFC to move to the [Ready for Released Stage](https://github.com/emberjs/rfcs#ready-for-release).

<details>
  <summary>Exploring Stage Description</summary>

This stage is entered when the Ember team believes the concept described in the RFC should be pursued, but the RFC may still need some more work, discussion, answers to open questions, and/or a champion before it can move to the next stage.

An RFC is moved into Exploring with consensus of the relevant teams. The relevant team expects to spend time helping to refine the proposal. The RFC remains a PR and will have an `Exploring` label applied.

An Exploring RFC that is successfully completed can move to [Accepted](https://github.com/emberjs/rfcs#accepted) with an FCP is required as in the existing process. It may also be moved to [Closed](https://github.com/emberjs/rfcs#closed) with an FCP.
</details>

<details>
  <summary>Accepted Stage Description</summary>

To move into the "accepted stage" the RFC must have complete prose and have successfully passed through an "FCP to Accept" period in which the community has weighed in and consensus has been achieved on the direction. The relevant teams believe that the proposal is well-specified and ready for implementation. The RFC has a champion within one of the relevant teams.

If there are unanswered questions, we have outlined them and expect that they will be answered before [Ready for Release](https://github.com/emberjs/rfcs#ready-for-release). 

When the RFC is accepted, the PR will be merged, and automation will open a new PR to move the RFC to the [Ready for Release](https://github.com/emberjs/rfcs#ready-for-release) stage. That PR should be used to track implementation progress and gain consensus to move to the next stage.

</details>

## Checklist to move to Exploring

- [ ] The team believes the concepts described in the RFC should be pursued.
- [ ] The label `S-Proposed` is removed from the PR and the label `S-Exploring` is added. 
- [ ] The Ember team is willing to work on the proposal to get it to Accepted

## Checklist to move to Accepted

- [ ] This PR has had the `Final Comment Period` label has been added to start the FCP
- [ ] The RFC is announced in #news-and-announcements in the Ember Discord.
- [ ] The RFC has complete prose, is well-specified and ready for implementation.
  - [ ] All sections of the RFC are filled out.
  - [ ] Any unanswered questions are outlined and expected to be answered before Ready for Release.
  - [ ] "How we teach this?" is sufficiently filled out.
- [ ] The RFC has a champion within one of the relevant teams.
- [ ] The RFC has consensus after the FCP period.
