### PR TITLE
Deprecate ember-fetch

### DIFF
--- a/text/0000-remove-ember-fetch.md
+++ b/text/0000-remove-ember-fetch.md
@@ -1,0 +1,141 @@
+---
+stage: accepted
+start-date: 2025-01-10T00:00:00.000Z
+release-date:
+release-versions:
+teams: # delete teams that aren't relevant
+  - cli
+  - data
+  - framework
+  - learning
+prs:
+  accepted: # update this to the PR that you propose your RFC in
+project-link:
+---
+
+<!---
+Directions for above:
+
+stage: Leave as is
+start-date: Fill in with today's date, 2032-12-01T00:00:00.000Z
+release-date: Leave as is
+release-versions: Leave as is
+teams: Include only the [team(s)](README.md#relevant-teams) for which this RFC applies
+prs:
+  accepted: Fill this in with the URL for the Proposal RFC PR
+project-link: Leave as is
+-->
+
+<-- Replace "RFC title" with the title of your RFC -->
+# Deprecate and Remove ember-fetch 
+
+## Summary
+
+This RFC proposes removing `ember-fetch` from the blueprint for new projects, and recommends alternative, more native, ways of having "managed fetch".
+
+## Motivation
+
+the package, `ember-fetch`, does a fair bit of deceptive and incorrect behavior that is incompatible with modern JavaScript tooling, such as _being_ `ember-fetch`, yet only importing from `fetch`.
+
+## Transition Path
+
+- Remove ember-fetch from all blueprints
+- Deprecate the npm package and archieve the github repo.
+- Migrate to an alternative for "managed fetch" 
+
+### What does `ember-fetch` do?
+
+_primarily_, it wraps the native `fetch` in `waitForPromise` from `@ember/test-waiters` (aka "settled state integration").
+
+
+secondarily, but not popularly used, are a series of utilities (e.g.: for checking kinds of errors). These could be copied into projects that use them. 
+
+### Using native `fetch`
+
+If you only use `ember-fetch` in route model-hooks, then the settled-state integration isn't used (or rather, you rely on the routing's settled-state integration, and `ember-fetch`'s settled-state integration is extraneous) 
+
+
+### Direct replacement
+
+
+To replace `ember-fetch`'s core-functionality using the least amount of effort involves adding a new utility in your apps:
+
+```ts
+import { waitForPromise } from '@ember/test-waiters';
+
+const nativeFetch = globalThis.fetch;
+
+export async function wrappedFetch(...args: Parameters<typeof nativeFetch>) {
+    let responsePromise = nativeFetch(...args);
+
+    waitForPromise(responsePromise);
+
+    let response = await responsePromise;
+
+    return new Proxy(response, {
+        get(target, prop, receiver) {
+            let original = Reflect.get(target, prop, receiver);
+
+            if (['json', 'text'].includes(prop)) {
+                return (...args) => {
+                    let parsePromise = original(...args);
+
+                    return waitForPromise(parsePromise);
+                }
+            }
+
+            return original;
+        }
+    });
+}
+```
+
+And then throughout your project, you could find and replace all imports of `import fetch from 'ember';` with `import { wrappedFetch } from 'app-name/utils/wrapped-fetch';`
+
+
+### Using a service
+
+Potentially an easier-to-manage implementation uses a service such as the following:
+
+```ts
+import Service from '@ember/service';
+import { waitFor } from '@ember/test-waiters';
+
+export default class Fetch extends Service {
+
+    @waitFor
+    @action
+    requestJson(...args: Parameters<typeof fetch>) {
+        return fetch(...args).then(response => response.json());
+    }
+
+    @waitFor
+    @action
+    requestText(...args: Parameters<typeof fetch>) {
+        return fetch(...args).then(response => response.text());
+    }
+}
+```
+
+### Using warp-drive / ember-data
+
+Docs available on https://github.com/emberjs/data/
+
+## How We Teach This
+
+- Add a deprecation notice to the ember-fetch README
+- Archive the ember-fetch repo
+- Remove ember-fetch from the blueprints
+- Remove ember-fetch  from the guides (only one reference per version)
+
+## Drawbacks
+
+- if we keep ember-fetch is not compatible with modern tooling and modern SSR approaches
+
+## Alternatives
+
+- n/a
+
+## Unresolved questions
+
+none

--- a/text/1065-remove-ember-fetch.md
+++ b/text/1065-remove-ember-fetch.md
@@ -74,7 +74,7 @@ export async function waitForFetch<Value>(fetchPromise: Promise<Value>) {
 
             if (['json', 'text', 'arrayBuffer', 'blob', 'formData'].includes(prop)) {
                 return (...args) => {
-                    let parsePromise = original(...args);
+                    let parsePromise = original.call(target, ...args);
 
                     return waitForPromise(parsePromise);
                 }

--- a/text/1065-remove-ember-fetch.md
+++ b/text/1065-remove-ember-fetch.md
@@ -93,7 +93,7 @@ To have a single import mirroring the behavior of `ember-fetch`, _in full_, folk
 import { waitForFetch } from '@ember/test-waiters';
 
 export function wrappedFetch(...args: Parameters<typeof fetch>) {
-    return wrappedFetch(fetch(...args));
+    return waitForFetch(fetch(...args));
 }
 ```
 

--- a/text/1065-remove-ember-fetch.md
+++ b/text/1065-remove-ember-fetch.md
@@ -62,10 +62,8 @@ To replace `ember-fetch`'s core-functionality using the least amount of effort i
 ```ts
 import { waitForPromise } from '@ember/test-waiters';
 
-const nativeFetch = globalThis.fetch;
-
 export async function wrappedFetch(...args: Parameters<typeof nativeFetch>) {
-    let responsePromise = nativeFetch(...args);
+    let responsePromise = fetch(...args);
 
     waitForPromise(responsePromise);
 
@@ -75,7 +73,7 @@ export async function wrappedFetch(...args: Parameters<typeof nativeFetch>) {
         get(target, prop, receiver) {
             let original = Reflect.get(target, prop, receiver);
 
-            if (['json', 'text'].includes(prop)) {
+            if (['json', 'text', 'arrayBuffer', 'blob', 'formData'].includes(prop)) {
                 return (...args) => {
                     let parsePromise = original(...args);
 

--- a/text/1065-remove-ember-fetch.md
+++ b/text/1065-remove-ember-fetch.md
@@ -26,7 +26,6 @@ prs:
 project-link: Leave as is
 -->
 
-<-- Replace "RFC title" with the title of your RFC -->
 # Deprecate and Remove ember-fetch 
 
 ## Summary
@@ -48,7 +47,7 @@ the package, `ember-fetch`, does a fair bit of deceptive and incorrect behavior 
 _primarily_, it wraps the native `fetch` in `waitForPromise` from `@ember/test-waiters` (aka "settled state integration").
 
 
-secondarily, but not popularly used, are a series of utilities (e.g.: for checking kinds of errors). These could be copied into projects that use them. 
+secondarily, but not popularly used, are a series of utilities (e.g.: for checking kinds of errors). These could be copied into projects that use them and modified to fit each project's needs. 
 
 ### Using native `fetch`
 
@@ -91,6 +90,7 @@ export async function wrappedFetch(...args: Parameters<typeof nativeFetch>) {
 ```
 
 And then throughout your project, you could find and replace all imports of `import fetch from 'ember';` with `import { wrappedFetch } from 'app-name/utils/wrapped-fetch';`
+
 
 
 ### Using a service

--- a/text/1065-remove-ember-fetch.md
+++ b/text/1065-remove-ember-fetch.md
@@ -57,17 +57,16 @@ If you only use `ember-fetch` in route model-hooks, then the settled-state integ
 ### Direct replacement
 
 
-To replace `ember-fetch`'s core-functionality using the least amount of effort involves adding a new utility in your apps:
+To replace `ember-fetch`'s core-functionality using the least amount of effort involves adding a new utility in `@ember/test-waiters`, `waitForFetch`:
 
 ```ts
-import { waitForPromise } from '@ember/test-waiters';
+// in @ember/test-waiters
+import { waitForPromise } from './wait-for-promise';
 
-export async function wrappedFetch(...args: Parameters<typeof nativeFetch>) {
-    let responsePromise = fetch(...args);
+export async function waitForFetch<Value>(fetchPromise: Promise<Value>) {
+    waitForPromise(fetchPromise);
 
-    waitForPromise(responsePromise);
-
-    let response = await responsePromise;
+    let response = await fetchPromise;
 
     return new Proxy(response, {
         get(target, prop, receiver) {
@@ -86,6 +85,18 @@ export async function wrappedFetch(...args: Parameters<typeof nativeFetch>) {
     });
 }
 ```
+
+
+To have a single import mirroring the behavior of `ember-fetch`, _in full_, folks can still provide a single export that does:
+
+```ts
+import { waitForFetch } from '@ember/test-waiters';
+
+export function wrappedFetch(...args: Parameters<typeof fetch>) {
+    return wrappedFetch(fetch(...args));
+}
+```
+
 
 And then throughout your project, you could find and replace all imports of `import fetch from 'ember';` with `import { wrappedFetch } from 'app-name/utils/wrapped-fetch';`
 
@@ -133,6 +144,7 @@ Docs available on https://github.com/emberjs/data/
 ## Alternatives
 
 - n/a
+- ask folks to wrap and proxy fetch themselves
 
 ## Unresolved questions
 

--- a/text/1065-remove-ember-fetch.md
+++ b/text/1065-remove-ember-fetch.md
@@ -9,7 +9,7 @@ teams: # delete teams that aren't relevant
   - framework
   - learning
 prs:
-  accepted: # update this to the PR that you propose your RFC in
+  accepted: https://github.com/emberjs/rfcs/pull/1065
 project-link:
 ---
 


### PR DESCRIPTION
<!-- If you are proposing a new RFC, please fill out the below template. 
If not, please remove the below contents
-->

# Propose Deprecating ember-fetch

[Rendered](https://github.com/emberjs/rfcs/blob/remove-ember-fetch/text/1065-remove-ember-fetch.md)

<!-- Update the below to link to the rendered version of your RFC. 
The URL can be interpolated below or can be found by going to the files tab
and choosing `View file' from the `...' menu in the right hand corner of the file. -->


## Summary

This pull request is proposing a new RFC.

To succeed, it will need to pass into the [Exploring Stage](https://github.com/emberjs/rfcs#exploring), followed by the [Accepted Stage](https://github.com/emberjs/rfcs#accepted).

A Proposed or Exploring RFC may also move to the [Closed Stage](https://github.com/emberjs/rfcs#closed) if it is withdrawn by the author or if it is rejected by the Ember team. This requires an "FCP to Close" period.

**An FCP is required before merging this PR to advance to Accepted.**

Upon merging this PR, automation will open a draft PR for this RFC to move to the [Ready for Released Stage](https://github.com/emberjs/rfcs#ready-for-release).

<details>
  <summary>Exploring Stage Description</summary>

This stage is entered when the Ember team believes the concept described in the RFC should be pursued, but the RFC may still need some more work, discussion, answers to open questions, and/or a champion before it can move to the next stage.

An RFC is moved into Exploring with consensus of the relevant teams. The relevant team expects to spend time helping to refine the proposal. The RFC remains a PR and will have an `Exploring` label applied.

An Exploring RFC that is successfully completed can move to [Accepted](https://github.com/emberjs/rfcs#accepted) with an FCP is required as in the existing process. It may also be moved to [Closed](https://github.com/emberjs/rfcs#closed) with an FCP.
</details>

<details>
  <summary>Accepted Stage Description</summary>

To move into the "accepted stage" the RFC must have complete prose and have successfully passed through an "FCP to Accept" period in which the community has weighed in and consensus has been achieved on the direction. The relevant teams believe that the proposal is well-specified and ready for implementation. The RFC has a champion within one of the relevant teams.

If there are unanswered questions, we have outlined them and expect that they will be answered before [Ready for Release](https://github.com/emberjs/rfcs#ready-for-release). 

When the RFC is accepted, the PR will be merged, and automation will open a new PR to move the RFC to the [Ready for Release](https://github.com/emberjs/rfcs#ready-for-release) stage. That PR should be used to track implementation progress and gain consensus to move to the next stage.

</details>

## Checklist to move to Exploring

- [ ] The team believes the concepts described in the RFC should be pursued.
- [ ] The label `S-Proposed` is removed from the PR and the label `S-Exploring` is added. 
- [ ] The Ember team is willing to work on the proposal to get it to Accepted

## Checklist to move to Accepted

- [ ] This PR has had the `Final Comment Period` label has been added to start the FCP
- [ ] The RFC is announced in #news-and-announcements in the Ember Discord.
- [ ] The RFC has complete prose, is well-specified and ready for implementation.
  - [ ] All sections of the RFC are filled out.
  - [ ] Any unanswered questions are outlined and expected to be answered before Ready for Release.
  - [ ] "How we teach this?" is sufficiently filled out.
- [ ] The RFC has a champion within one of the relevant teams.
- [ ] The RFC has consensus after the FCP period.
