### PR TITLE
Update README to fix stages table - workaround a bug in markdown parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ Read more about the RFC [Stages].
 ## Stages
 [Stages]: #stages
 
+Here are all the stages that an RFC can be in:
+
 | Stage| Description| Requires FCP to enter? |
 | -----| -----------|----- |
 | [0 - Proposed](#Proposed) | A proposal for a change to Ember or its processes that is offered for community and team evaluation. | no |


### PR DESCRIPTION
This is not an RFC! I hope I don't break the CI to make this change 🙈 Edit: It looks like because of the path filter and the `required` this is unmergable 🫠 Maybe an admin can override? 

Here is why I'm making this change: 

Before: 

![Screenshot 2025-02-18 at 12 17 37](https://github.com/user-attachments/assets/663a09dc-70c4-49f8-9847-429d16ed72ec)

After: 

![Screenshot 2025-02-18 at 12 17 44](https://github.com/user-attachments/assets/b3ad9cf6-04f1-4135-b93d-aaddd263f096)
