### PR TITLE
Deprecate Observers

### DIFF
--- a/text/1115-deprecate-observable.md
+++ b/text/1115-deprecate-observable.md
@@ -1,0 +1,99 @@
+---
+stage: accepted
+start-date: 2025-06-16T00:00:00.000Z
+release-date:
+release-versions:
+teams: # delete teams that aren't relevant
+  - cli
+  - data
+  - framework
+  - learning
+  - steering
+  - typescript
+prs:
+  accepted: https://github.com/emberjs/rfcs/pull/1115
+project-link:
+---
+
+# Deprecate Observers
+
+## Summary
+
+Deprecate the `Observable` Mixin, `observer` helper, and public observer functionality.
+
+## Motivation
+
+Using observers has been soft-deprecated ever since the introduction of tracking. Removing
+support for them will significantly clean up the code base. (Note that for us to entirely
+remove observer support internally, we will likely need to deprecate other functionality
+in addition to what is include here.)
+
+Additionally, Ember has also not recommended the use of Mixins for a while. Since
+`Observable` uses the Mixin architecture, it will also need to be deprecated for us
+to fully remove Mixins.
+
+## Transition Path
+
+### Observable Mixin
+
+Some of the methods provided by `Observable` are available as standalone methods,
+for these the transition path is straight-forward:
+
+* `get` -> Import from `@ember/object`
+* `getProperties` -> Import from `@ember/object`
+* `set` -> Import from `@ember/object`
+* `setProperties` -> Import from `@ember/object`
+* `notifyPropertyChange` -> Import from `@ember/object`
+
+For sugar helpers they can easily be replaced with a bit more verbosity:
+
+* `incrementProperty`
+    ```js
+    this.count += 1; // Tracking
+    set(this, 'count', get(this, 'count') + 1); // Legacy 
+    ```
+* `decrementProperty`
+    ```js
+    this.count -= 1; // Tracking
+    set(this, 'count', get(this, 'count') - 1); // Legacy 
+    ```
+* `toggleProperty`
+    ```js
+    this.flag = !this.flag; // Tracking
+    set(this, 'flag', !get(this, 'flag')); // Legacy
+    ```
+
+For others, there will no replacement and code that depends on them
+will have to be refactored:
+
+* `addObserver`
+* `removeObserver`
+* `cacheFor`
+
+### Observable Helper
+
+This function does not work with native class syntax and as such, shouldn't be relied upon.
+It will not be replaced.
+
+## Exploration
+
+To validate this deprecation, I've tried removing this functionality in the following PRs:
+* Inline Observable Mixin: https://github.com/emberjs/ember.js/pull/20928
+* Remove `observer` helper and inlined Observable methods: https://github.com/emberjs/ember.js/pull/20937
+
+## How We Teach This
+
+We should remove all references to this functionality from the guides.
+
+## Drawbacks
+
+Many users probably rely on this functionality. However, it's almost certainly
+something that we don't want to support long-term.
+
+## Alternatives
+
+* Just inline this functionality so that we can at least get rid of Mixins.
+
+## Unresolved questions
+
+None

--- a/text/1115-deprecate-observable.md
+++ b/text/1115-deprecate-observable.md
@@ -33,7 +33,7 @@ Additionally, Ember has also not recommended the use of Mixins for a while. Sinc
 to fully remove Mixins.
 
 ## Transition Path
-
+A full deprecation guide is PR'd here: https://github.com/ember-learn/deprecation-app/pull/1407
 ### Observable Mixin
 
 Some of the methods provided by `Observable` are available as standalone methods,

--- a/text/1115-deprecate-observable.md
+++ b/text/1115-deprecate-observable.md
@@ -3,12 +3,10 @@ stage: accepted
 start-date: 2025-06-16T00:00:00.000Z
 release-date:
 release-versions:
-teams: # delete teams that aren't relevant
-  - cli
-  - data
+teams:
   - framework
+  - data
   - learning
-  - steering
   - typescript
 prs:
   accepted: https://github.com/emberjs/rfcs/pull/1115
@@ -19,21 +17,44 @@ project-link:
 
 ## Summary
 
-Deprecate the `Observable` Mixin, `observer` helper, and public observer functionality.
+Deprecate the `Observable` Mixin, `observer` helper, and public observer
+functionality, including:
+
+- The `Observable` mixin (`@ember/object/observable`) and the methods it adds
+  to `EmberObject` and its descendants:
+  - `get`, `set`, `getProperties`, `setProperties`
+  - `notifyPropertyChange`
+  - `addObserver`, `removeObserver`
+  - `incrementProperty`, `decrementProperty`, `toggleProperty`
+  - `cacheFor`
+- The `observer` helper from `@ember/object`
+- The standalone `addObserver` and `removeObserver` functions from
+  `@ember/object/observers`
+
+The standalone `get`, `set`, `getProperties`, `setProperties`, and
+`notifyPropertyChange` functions from `@ember/object` are not deprecated by
+this RFC.
 
 ## Motivation
 
-Using observers has been soft-deprecated ever since the introduction of tracking. Removing
-support for them will significantly clean up the code base. (Note that for us to entirely
-remove observer support internally, we will likely need to deprecate other functionality
-in addition to what is include here.)
+Using observers has been soft-deprecated ever since the introduction of
+tracking. The guides do not teach them, and eslint-plugin-ember's
+[`no-observers`](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-observers.md)
+rule has recommended against them for years. Removing support for them will
+significantly clean up the code base. (Note that for us to entirely remove
+observer support internally, we will likely need to deprecate other
+functionality in addition to what is included here.)
 
-Additionally, Ember has also not recommended the use of Mixins for a while. Since
-`Observable` uses the Mixin architecture, it will also need to be deprecated for us
-to fully remove Mixins.
+Additionally, Ember has also not recommended the use of Mixins for a while.
+Since `Observable` uses the Mixin architecture, it will also need to be
+deprecated for us to fully remove Mixins.
 
 ## Transition Path
+
 A full deprecation guide is PR'd here: https://github.com/ember-learn/deprecation-app/pull/1407
+
+The deprecations will target `until: '8.0.0'`.
+
 ### Observable Mixin
 
 Some of the methods provided by `Observable` are available as standalone methods,
@@ -44,6 +65,11 @@ for these the transition path is straight-forward:
 * `set` -> Import from `@ember/object`
 * `setProperties` -> Import from `@ember/object`
 * `notifyPropertyChange` -> Import from `@ember/object`
+
+The standalone functions are only needed when interoperating with legacy
+computed properties and Ember's proxies. Rather than adopting them long-term,
+most code should refactor `@computed` properties to native getters over
+`@tracked` state, at which point plain property access and assignment work.
 
 For sugar helpers they can easily be replaced with a bit more verbosity:
 
@@ -63,17 +89,57 @@ For sugar helpers they can easily be replaced with a bit more verbosity:
     set(this, 'flag', !get(this, 'flag')); // Legacy
     ```
 
-For others, there will no replacement and code that depends on them
+For others, there will be no replacement and code that depends on them
 will have to be refactored:
 
-* `addObserver`
-* `removeObserver`
-* `cacheFor`
+* `addObserver` (see below)
+* `removeObserver` (see below)
+* `cacheFor` — for memoization, use native getters with
+  [`@cached`](https://api.emberjs.com/ember/release/functions/@glimmer%2Ftracking/cached)
+  from `@glimmer/tracking`. There is no replacement for peeking at a cached
+  value without computing it.
 
-### Observable Helper
+### Observers
 
-This function does not work with native class syntax and as such, shouldn't be relied upon.
-It will not be replaced.
+The `observer` helper does not work with native class syntax and as such,
+shouldn't be relied upon. It will not be replaced, and neither will the
+standalone `addObserver` and `removeObserver` functions. The transition path
+depends on what the observer was doing.
+
+Observers that derive state from other state should become native getters over
+`@tracked` properties. The derivation then happens lazily when the value is
+read instead of eagerly when a dependency changes.
+
+Observers that perform side effects should be refactored so the side effect
+happens explicitly at the site of the mutation, for example in the action that
+performs the change.
+
+Observers used in classic components to react to argument changes, often to
+drive a third-party library, should become
+[modifiers](https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifiers/),
+which re-run when their arguments change and are tied to an element's
+lifecycle.
+
+Some libraries use observers to find out when tracked state has changed
+outside of rendering, for example ember-concurrency's `waitFor`, and patterns
+in ember-animated, ember-data, and ember-power-select. Today the only
+workarounds are polling via `requestAnimationFrame` or timers. Ember should
+expose a deliberately low-level API for consuming tracked state outside the
+renderer, likely building on
+`createCache` / `getValue` with a way to be notified of invalidation.
+Designing that API is left to a follow-up RFC, but the observer APIs
+deprecated here should not be removed until it exists.
+
+### Ecosystem impact
+
+- eslint-plugin-ember already ships `no-observers`, so no new lint rules are
+  needed. Its docs can link to the deprecation guide once it ships.
+- Addons that use observers (ember-concurrency, ember-animated,
+  ember-power-select, parts of ember-data) will need to migrate. The
+  `until: '8.0.0'` window is intended to give them time.
+- The published types for `@ember/object/observable`,
+  `@ember/object/observers`, and `observer` will be marked `@deprecated` and
+  removed along with the APIs.
 
 ## Exploration
 
@@ -83,17 +149,35 @@ To validate this deprecation, I've tried removing this functionality in the foll
 
 ## How We Teach This
 
-We should remove all references to this functionality from the guides.
+We should remove all references to this functionality from the guides and mark
+the relevant API docs as deprecated. Observers are not part of the modern
+learning path, so no re-organization is needed.
+
+The deprecation guide (PR'd above) covers each use case, showing both the
+incremental migration for legacy `EmberObject` / `@computed` code and the
+final native-class form. The deprecation should also be mentioned in the
+release blog post.
 
 ## Drawbacks
 
 Many users probably rely on this functionality. However, it's almost certainly
 something that we don't want to support long-term.
 
+Non-rendering integration with the reactivity system has no efficient
+replacement until the low-level API described above exists. The deprecation
+can ship first, but removal must wait for that API.
+
 ## Alternatives
 
 * Just inline this functionality so that we can at least get rid of Mixins.
+* Keep the standalone `addObserver`/`removeObserver` functions as the
+  low-level integration API. Rejected because they expose the legacy eager
+  notification model rather than an autotracking primitive.
+* Do nothing, which blocks removing Mixins and means maintaining two
+  reactivity systems indefinitely.
 
 ## Unresolved questions
 
-None
+The design of the low-level API for consuming tracked state outside the
+renderer is left to a follow-up RFC. This RFC takes the position that the
+deprecated APIs are not removed until that API ships.


### PR DESCRIPTION
# Propose Deprecating Observers

## [Rendered](https://github.com/wagenet/rfcs/blob/deprecate-observable/text/1115-deprecate-observable.md)

## Summary

This pull request is proposing a new RFC.

To succeed, it will need to pass into the [Exploring Stage](https://github.com/emberjs/rfcs#exploring), followed by the [Accepted Stage](https://github.com/emberjs/rfcs#accepted).

A Proposed or Exploring RFC may also move to the [Closed Stage](https://github.com/emberjs/rfcs#closed) if it is withdrawn by the author or if it is rejected by the Ember team. This requires an "FCP to Close" period.

**An FCP is required before merging this PR to advance to Accepted.**

Upon merging this PR, automation will open a draft PR for this RFC to move to the [Ready for Released Stage](https://github.com/emberjs/rfcs#ready-for-release).

<details>
  <summary>Exploring Stage Description</summary>

This stage is entered when the Ember team believes the concept described in the RFC should be pursued, but the RFC may still need some more work, discussion, answers to open questions, and/or a champion before it can move to the next stage.

An RFC is moved into Exploring with consensus of the relevant teams. The relevant team expects to spend time helping to refine the proposal. The RFC remains a PR and will have an `Exploring` label applied.

An Exploring RFC that is successfully completed can move to [Accepted](https://github.com/emberjs/rfcs#accepted) with an FCP is required as in the existing process. It may also be moved to [Closed](https://github.com/emberjs/rfcs#closed) with an FCP.
</details>

<details>
  <summary>Accepted Stage Description</summary>

To move into the "accepted stage" the RFC must have complete prose and have successfully passed through an "FCP to Accept" period in which the community has weighed in and consensus has been achieved on the direction. The relevant teams believe that the proposal is well-specified and ready for implementation. The RFC has a champion within one of the relevant teams.

If there are unanswered questions, we have outlined them and expect that they will be answered before [Ready for Release](https://github.com/emberjs/rfcs#ready-for-release). 

When the RFC is accepted, the PR will be merged, and automation will open a new PR to move the RFC to the [Ready for Release](https://github.com/emberjs/rfcs#ready-for-release) stage. That PR should be used to track implementation progress and gain consensus to move to the next stage.

</details>

## Checklist to move to Exploring

- [ ] The team believes the concepts described in the RFC should be pursued.
- [ ] The label `S-Proposed` is removed from the PR and the label `S-Exploring` is added. 
- [ ] The Ember team is willing to work on the proposal to get it to Accepted

## Checklist to move to Accepted

- [ ] This PR has had the `Final Comment Period` label has been added to start the FCP
- [ ] The RFC is announced in #news-and-announcements in the Ember Discord.
- [ ] The RFC has complete prose, is well-specified and ready for implementation.
  - [ ] All sections of the RFC are filled out.
  - [ ] Any unanswered questions are outlined and expected to be answered before Ready for Release.
  - [ ] "How we teach this?" is sufficiently filled out.
- [ ] The RFC has a champion within one of the relevant teams.
- [ ] The RFC has consensus after the FCP period.
