### PR TITLE
Revert "Advance RFC #1065 `"Deprecate and Remove ember-fetch"` to Stage Released"

### DIFF
--- a/text/1065-remove-ember-fetch.md
+++ b/text/1065-remove-ember-fetch.md
@@ -1,10 +1,8 @@
 ---
-stage: released
+stage: ready-for-release
 start-date: 2025-01-10T00:00:00.000Z
 release-date:
 release-versions:
-  "@ember/test-waiters": "4.1.0"
-  "ember-cli": "6.6.0"
 teams:
   - cli
   - data
@@ -13,7 +11,6 @@ teams:
 prs:
   accepted: 'https://github.com/emberjs/rfcs/pull/1065'
   ready-for-release: 'https://github.com/emberjs/rfcs/pull/1081'
-  released: 'https://github.com/emberjs/rfcs/pull/1104'
 project-link:
 ---
 


### PR DESCRIPTION
Reverts emberjs/rfcs#1104

ope, 6.6 isn't actually out yet 🙈 