### PR TITLE
Strict resolver

### DIFF
--- a/text/0000-default-strict-resolver.md
+++ b/text/0000-default-strict-resolver.md
@@ -1,0 +1,127 @@
+---
+stage: accepted
+start-date: 2025-08-13T00:00:00.000Z
+release-date: # In format YYYY-MM-DDT00:00:00.000Z
+release-versions:
+teams:
+  - framework
+prs:
+  accepted: # Fill this in with the URL for the Proposal RFC PR
+project-link:
+suite: 
+---
+
+# Default Strict Resolver
+
+## Summary
+
+This RFC proposes shipping a built-in strict resolver as the default in Ember applications, replacing the current `ember-resolver` package. The strict resolver uses explicit module registration through `import.meta.glob('...', { eager: true })` (or manually) instead of dynamic string-based lookups, providing better tree-shaking, build-time optimization, and improved developer experience with static analysis tools.
+
+## Motivation
+
+The current `ember-resolver` requires that an `Application` has a modulePrefix, and that every resolver registration begins with that `modulePrefix`. As we start to move towards strict ESM applications, this requirement is unneeded. Previously, if folks wanted to use `import.meta.glob()` in their vite apps (or test-apps (or minimal apps)), they would have to iterate the result of `import.meta.glob` to prepend the `modulePrefix` -- which is entirely boilerplate.
+
+> [!NOTE]
+> The strict resolver does not affect apps using broccoli or `@embroider/virtual/compat-modules`
+
+## Detailed design
+
+The strict resolver will be built into Ember applications and imported from `@ember/application` instead of requiring a separate `ember-resolver` package. Applications will register modules explicitly using a `modules` property containing import map objects.
+
+Example:
+
+```javascript
+// Before | with ember-resolver
+import Application from '@ember/application';
+import Resolver from 'ember-resolver';
+import config from 'my-app/config/environment';
+
+export default class App extends Application {
+  modulePrefix = config.modulePrefix;
+  podModulePrefix = config.podModulePrefix;
+  Resolver = Resolver.withModules({
+    [`${config.modulePrefix}/router`]: { default: Router },
+    [`${config.modulePrefix}/services/current-user`]: { default: CurrentUserService },
+    // potentially thousands of manual entries
+    // and all imports need to be at the top of the file as well -- doubling the lines per resolver entries
+  });
+}
+```
+
+```javascript
+// After: 
+import Application from '@ember/application';
+import Router from './router';
+import config from 'my-app/config/environment';
+
+export default class App extends Application {
+  modules = {
+    './router': { default: Router },
+    './services/current-user': { default: CurrentUserService },
+    
+    // author-time is easy
+    ...import.meta.glob('./services/**/*', { eager: true }),
+    ...import.meta.glob('./routes/*', { eager: true }),
+    ...import.meta.glob('./controllers/*', { eager: true }),
+    ...import.meta.glob('./components/**/*', { eager: true }),
+    ...import.meta.glob('./templates/**/*', { eager: true }),
+    ...import.meta.glob('./helpers/*', { eager: true }),
+    ...import.meta.glob('./modifiers/*', { eager: true }),
+  };
+}
+```
+
+### Module Registration Format
+
+The `modules` object maps module paths to either:
+1. Module objects with named exports: `{ default: ExportableType, namedExport: AnotherType }`
+2. Direct exports for default-only modules: `ExportableType`
+
+```javascript
+modules = {
+  // Full module object
+  './services/current-user': { default: CurrentUserService },
+  './components/user-avatar': { default: UserAvatarComponent },
+  
+  // Shorthand for default exports
+  './services/session': SessionService,
+  
+  // Automatic splat via import.meta.glob
+  ...import.meta.glob('./services/**/*', { eager: true }),
+}
+```
+
+
+## How we teach this
+
+API Docs will explain the above usages.
+We aren't ready to add this to the guides as the community may not be ready for "minimal app" (which may need to be a different app blueprint from the current `@ember/app-blueprint`).
+
+## Appendix
+
+
+Libraries can provide helper functions for registering their modules, services, etc:
+
+```javascript
+// Library provides a registry builder
+import { buildRegistry } from 'ember-strict-application-resolver/build-registry';
+import libraryRegistry from 'some-library/registry';
+
+export default class App extends Application {
+  modules = {
+    ...import.meta.glob('./services/**/*', { eager: true }),
+    ...libraryRegistry(), // Library-provided modules
+    './services/custom': CustomService,
+  };
+}
+```
+
+See: [the polyfill](https://github.com/NullVoxPopuli/ember-strict-application-resolver?tab=readme-ov-file#buildregistry) for more information.
+
+## Drawbacks
+
+n/a - folks can keep using ember-resolver. ember-resolver is _not_ deprecated.
+
+## Unresolved questions
+
+n/a

--- a/text/1132-default-strict-resolver.md
+++ b/text/1132-default-strict-resolver.md
@@ -63,10 +63,7 @@ export default class App extends Application {
     ...import.meta.glob('./services/**/*', { eager: true }),
     ...import.meta.glob('./routes/*', { eager: true }),
     ...import.meta.glob('./controllers/*', { eager: true }),
-    ...import.meta.glob('./components/**/*', { eager: true }),
     ...import.meta.glob('./templates/**/*', { eager: true }),
-    ...import.meta.glob('./helpers/*', { eager: true }),
-    ...import.meta.glob('./modifiers/*', { eager: true }),
   };
 }
 ```

--- a/text/1132-default-strict-resolver.md
+++ b/text/1132-default-strict-resolver.md
@@ -15,14 +15,14 @@ suite:
 
 ## Summary
 
-This RFC proposes shipping a built-in strict resolver as the default in Ember applications, replacing the current `ember-resolver` package. The strict resolver uses explicit module registration through `import.meta.glob('...', { eager: true })` (or manually) instead of dynamic string-based lookups, providing better tree-shaking, build-time optimization, and improved developer experience with static analysis tools.
+This RFC proposes shipping a built-in (opt-in) strict resolver as the default in Ember applications, replacing the current `ember-resolver` package. The strict resolver uses explicit module registration through `import.meta.glob('...', { eager: true })` (or manually) instead of dynamic string-based lookups, providing better tree-shaking, build-time optimization, and improved developer experience with static analysis tools.
 
 ## Motivation
 
 The current `ember-resolver` requires that an `Application` has a modulePrefix, and that every resolver registration begins with that `modulePrefix`. As we start to move towards strict ESM applications, this requirement is unneeded. Previously, if folks wanted to use `import.meta.glob()` in their vite apps (or test-apps (or minimal apps)), they would have to iterate the result of `import.meta.glob` to prepend the `modulePrefix` -- which is entirely boilerplate.
 
 > [!NOTE]
-> The strict resolver does not affect apps using broccoli or `@embroider/virtual/compat-modules`
+> The strict resolver does not affect existing apps using broccoli or `@embroider/virtual/compat-modules`, though users of those environments could opt in to this new behavior.
 
 ## Detailed design
 

--- a/text/1132-default-strict-resolver.md
+++ b/text/1132-default-strict-resolver.md
@@ -28,6 +28,9 @@ The current `ember-resolver` requires that an `Application` has a modulePrefix, 
 
 The strict resolver will be built into Ember applications and imported from `@ember/application` instead of requiring a separate `ember-resolver` package. Applications will register modules explicitly using a `modules` property containing import map objects.
 
+> [!NOTE]
+> This keeps all existing default ember-resolver semantics -- locking down the behaviors as the stable legacy thing and won't change and will no longer be extensible. (e.g.: no custom resolvers will be allowed with the `modules = {}` object.
+
 Example:
 
 ```javascript
@@ -118,6 +121,20 @@ export default class App extends Application {
 ```
 
 See: [the polyfill](https://github.com/NullVoxPopuli/ember-strict-application-resolver?tab=readme-ov-file#buildregistry) for more information.
+
+However, in existing projects, it's perfectly safe to use `compat-modules` from `@embroider/virtual`[^pending-embroider-support]
+
+```javascript
+import compatModules from '@embroider/virtual/compat-modules';
+
+export default class App extends Application {
+    modules = {
+        ...compatModules,
+    }
+}
+```
+
+[^pending-embroider-support]: embroider currently prefixes the compat modules with the `modulePrefix`. That won't exist, so embroider needs to ship a feature that detects this usage of `Application`, and omits the `modulePrefix`
 
 ## Drawbacks
 

--- a/text/1132-default-strict-resolver.md
+++ b/text/1132-default-strict-resolver.md
@@ -97,6 +97,8 @@ modules = {
 API Docs will explain the above usages.
 We aren't ready to add this to the guides as the community may not be ready for "minimal app" (which may need to be a different app blueprint from the current `@ember/app-blueprint`).
 
+For folks that wish to adopt this pattern today, they can use [the polyfill](https://github.com/NullVoxPopuli/ember-strict-application-resolver)
+
 ## Appendix
 
 

--- a/text/1132-default-strict-resolver.md
+++ b/text/1132-default-strict-resolver.md
@@ -6,7 +6,7 @@ release-versions:
 teams:
   - framework
 prs:
-  accepted: # Fill this in with the URL for the Proposal RFC PR
+  accepted: https://github.com/emberjs/rfcs/pull/1132
 project-link:
 suite: 
 ---

--- a/text/1132-default-strict-resolver.md
+++ b/text/1132-default-strict-resolver.md
@@ -97,6 +97,8 @@ modules = {
 API Docs will explain the above usages.
 We aren't ready to add this to the guides as the community may not be ready for "minimal app" (which may need to be a different app blueprint from the current `@ember/app-blueprint`).
 
+_Also, the existing guides have no information on resolving or ember-resolver_.
+
 For folks that wish to adopt this pattern today, they can use [the polyfill](https://github.com/NullVoxPopuli/ember-strict-application-resolver)
 
 ## Appendix


### PR DESCRIPTION
Demo app: https://github.com/NullVoxPopuli/smol-ember-app/
Difference being that instead of importing from a library, we'd still use `@ember/application`

<!-- If you are proposing a new RFC, please fill out the below template. 
If not, please remove the below contents
-->

# Propose adding a default Strict Resolver as an alternative to using ember-resolver

<!-- Update the below to link to the rendered version of your RFC. 
The URL can be interpolated below or can be found by going to the files tab
and choosing `View file' from the `...' menu in the right hand corner of the file. -->

## [Rendered](https://github.com/emberjs/rfcs/blob/nvp/strict-resolver/text/1132-default-strict-resolver.md)

## Summary

This pull request is proposing a new RFC.

To succeed, it will need to pass into the [Exploring Stage](https://github.com/emberjs/rfcs#exploring), followed by the [Accepted Stage](https://github.com/emberjs/rfcs#accepted).

A Proposed or Exploring RFC may also move to the [Closed Stage](https://github.com/emberjs/rfcs#closed) if it is withdrawn by the author or if it is rejected by the Ember team. This requires an "FCP to Close" period.

**An FCP is required before merging this PR to advance to Accepted.**

Upon merging this PR, automation will open a draft PR for this RFC to move to the [Ready for Released Stage](https://github.com/emberjs/rfcs#ready-for-release).

<details>
  <summary>Exploring Stage Description</summary>

This stage is entered when the Ember team believes the concept described in the RFC should be pursued, but the RFC may still need some more work, discussion, answers to open questions, and/or a champion before it can move to the next stage.

An RFC is moved into Exploring with consensus of the relevant teams. The relevant team expects to spend time helping to refine the proposal. The RFC remains a PR and will have an `Exploring` label applied.

An Exploring RFC that is successfully completed can move to [Accepted](https://github.com/emberjs/rfcs#accepted) with an FCP is required as in the existing process. It may also be moved to [Closed](https://github.com/emberjs/rfcs#closed) with an FCP.
</details>

<details>
  <summary>Accepted Stage Description</summary>

To move into the "accepted stage" the RFC must have complete prose and have successfully passed through an "FCP to Accept" period in which the community has weighed in and consensus has been achieved on the direction. The relevant teams believe that the proposal is well-specified and ready for implementation. The RFC has a champion within one of the relevant teams.

If there are unanswered questions, we have outlined them and expect that they will be answered before [Ready for Release](https://github.com/emberjs/rfcs#ready-for-release). 

When the RFC is accepted, the PR will be merged, and automation will open a new PR to move the RFC to the [Ready for Release](https://github.com/emberjs/rfcs#ready-for-release) stage. That PR should be used to track implementation progress and gain consensus to move to the next stage.

</details>

## Checklist to move to Exploring

- [ ] The team believes the concepts described in the RFC should be pursued.
- [ ] The label `S-Proposed` is removed from the PR and the label `S-Exploring` is added. 
- [ ] The Ember team is willing to work on the proposal to get it to Accepted

## Checklist to move to Accepted

- [ ] This PR has had the `Final Comment Period` label has been added to start the FCP
- [ ] The RFC is announced in #news-and-announcements in the Ember Discord.
- [ ] The RFC has complete prose, is well-specified and ready for implementation.
  - [ ] All sections of the RFC are filled out.
  - [ ] Any unanswered questions are outlined and expected to be answered before Ready for Release.
  - [ ] "How we teach this?" is sufficiently filled out.
- [ ] The RFC has a champion within one of the relevant teams.
- [ ] The RFC has consensus after the FCP period.
