### PR TITLE
Introduce Template-only Class Components

### DIFF
--- a/text/0000-template-only-class-component.md
+++ b/text/0000-template-only-class-component.md
@@ -1,0 +1,259 @@
+---
+stage: accepted
+start-date: 2025-08-14T00:00:00.000Z
+release-date: # In format YYYY-MM-DDT00:00:00.000Z
+release-versions:
+teams:
+  - framework
+  - typescript
+prs:
+  accepted: # Fill this in with the URL for the Proposal RFC PR
+project-link:
+suite: 
+---
+
+# Template-Only Class Components
+
+## Summary
+
+Add a new `TemplateOnly` base class to `@glimmer/component` that enables template-only components to be defined as classes, allowing them to support TypeScript generics for better type safety.
+
+## Motivation
+
+Currently, template-only components in Ember are defined using `const` declarations like this:
+
+```typescript
+export const Demo = <template>
+  {{@value}}
+</template>
+```
+
+However, this approach has a significant limitation: **it's not possible to specify generic type parameters** with `const` declarations in TypeScript. This prevents template-only components from having proper type safety when they need to work with generic data types.
+
+For example, consider a template-only component that should work with different types of values:
+
+```typescript
+import type { TOC } from '@ember/component/template-only';
+
+// This doesn't work - can't add generics to const declarations
+export const Demo<Value>: TOC<{ // ❌ Syntax error
+  Args: {
+    value: Value
+  }
+}> = <template>  
+  {{@value}}
+</template>
+```
+
+This limitation forces developers to either:
+1. Give up type safety and use `any` or `unknown` for component arguments
+2. Create unnecessary `@glimmer/component` Component classes to add TypeScript generics -- [these are slower][^template-only-faster]
+3. Create multiple duplicate components for different types
+
+Class-based components don't have the syntax limitation:
+
+```glimmer-ts
+interface ComponentSignature<Value> {
+  Args: {
+    value: Value;
+  };
+}
+
+class Demo<Value> extends Component<ComponentSignature<Value>> {
+  <template>
+    {{@value}}
+  </template>
+}
+```
+
+Creating a full component class when you only need a template feels like overkill and goes against the principle of template-only components [being lightweight][^template-only-faster].
+
+[^template-only-faster]: template-only components are 7 to 26% faster than the `Component` from `@glimmer/component` -- https://nullvoxpopuli.com/2023-12-20-template-only-vs-class-components
+
+## Detailed design
+
+### New `TemplateOnly` Export
+
+This RFC proposes adding a new `TemplateOnly` export to `@glimmer/component` that can be used as a base class for template-only components:
+
+```glimmer-ts
+import { TemplateOnly } from '@glimmer/component';
+
+class Demo<Value> extends TemplateOnly<{
+  Args: {
+    value: Value;
+  };
+}> {
+  <template>
+    {{@value}}
+  </template>
+}
+
+export default Demo;
+```
+
+At runtime, this is _functionally_ the same as the `const` template-only components today.
+In that the `TemplateOnly` class we re-export from `@glimmer/component` would be associated with a light-weight component manager, as template-only components are today.
+
+There is no `this`, so there will need to be a lint that forbids use of `this` in `TemplateOnly` classes.
+
+### Compilation
+
+Classes have a feature similar to functions, which is useful for defining more than one in the same file: hoisting.
+
+If we compiled to the `const` representation that we have today, we'd have a disagreement between editor expectations and runtime behavior.
+
+So compilation of these components should use `var` instead of `const`.
+
+Otherwise, all other aspects can be the same as existing compilation today:
+
+```glimmer-ts
+// Source
+class Demo<Value> extends TemplateOnly<{
+  Args: { value: Value };
+}> {
+  <template>
+    {{@value}}
+  </template>
+}
+
+// Compiled output (same as current template-only components)
+import { precompileTemplate } from '@ember/template-compilation';
+import { setComponentTemplate } from '@ember/component';
+import templateOnlyComponent from '@ember/component/template-only';
+
+export default setComponentTemplate(
+  precompileTemplate(`{{@value}}`, {
+    strictMode: true,
+    scope: () => ({}),
+  }),
+  templateOnlyComponent()
+);
+```
+
+Existing babel-based compnoent compilation occurs in [`babel-plugin-ember-template-compilation`](https://github.com/emberjs/babel-plugin-ember-template-compilation).
+But the `<template>` transforms occur in [`content-tag`](https://github.com/embroider-build/content-tag), and `content-tag`'s output would be:
+```typescript
+class Demo<Value> extends TemplateOnly<{
+  Args: { value: Value };
+}> {
+  static {
+    template(`{{@value}}`, { component: this, scope: () => ({}) })
+  }
+}
+```
+So `babel-plugin-ember-template-compilation` could optimze this to:
+```javascript
+var Demo = template(`{{@value}}`, { scope: () => ({}) });
+```
+
+However, because we also support compile-less environments, the `TemplateOnly` export would _work_ if it made it to the runtime.
+
+[Here is an example implementation of that fallback behavior in the Limber REPL]()
+
+### Usage Examples
+
+#### Simple Generic Component
+
+```typescript
+import { TemplateOnly } from '@glimmer/component';
+
+class ItemDisplay<T> extends TemplateOnly<{
+  Args: {
+    item: T;
+    displayProperty: keyof T;
+  };
+}> {
+  <template>
+    <div class="item">
+      {{get @item @displayProperty}}
+    </div>
+  </template>
+}
+```
+
+#### Component with Blocks
+
+```typescript
+import { TemplateOnly } from '@glimmer/component';
+
+class List<T> extends TemplateOnly<{
+  Args: {
+    items: T[];
+  };
+  Blocks: {
+    default: [item: T, index: number];
+    empty: [];
+  };
+}> {
+  <template>
+    {{#if @items.length}}
+      <ul>
+        {{#each @items as |item index|}}
+          <li>{{yield item index}}</li>
+        {{/each}}
+      </ul>
+    {{else}}
+      {{yield to="empty"}}
+    {{/if}}
+  </template>
+}
+```
+
+
+## How we teach this
+
+The feature introduces one new concept: **Template-Only Class Components**. These are components that use class syntax purely for TypeScript generic support while maintaining template-only semantics at runtime.
+
+> [!IMPORTANT]
+> More importantly though, our eslint plugin, should have a way to automatically flip between the component formats to reduce the amount of shuffling that developers have to do when they need to switch formats -- this may also make sense as a glint code-action.
+
+### Documentation Updates
+
+#### TypeScript Guide Updates
+
+The [TypeScript: Invokables](https://guides.emberjs.com/release/typescript/core-concepts/invokables/) guide should be updated to include:
+
+1. A new section explaining when and how to use `TemplateOnly` for generic template-only components
+2. Examples showing the above examples using generics
+3. Guidance on choosing between `const` and `class extends TemplateOnly`
+
+### Migration Path
+
+_There is no need for migration_.
+
+This feature is purely additive and doesn't affect existing template-only components. Developers can continue (and likely should prefer) using the current `const` syntax for simple cases and opt into the class syntax when they need generics.
+
+```typescript
+// Existing syntax still works
+const SimpleComponent = <template>
+  <p>Hello {{@name}}</p>
+</template>
+
+// New syntax for when you need generics
+class GenericComponent<T> extends TemplateOnly<{
+  Args: { data: T };
+}> {
+  <template>
+    <pre>{{json-stringify @data}}</pre>
+  </template>
+}
+```
+
+## Drawbacks
+
+### Learning Complexity
+
+Adding another way to define template-only components could be confusing for new users. However, this is mitigated by:
+- The feature is TypeScript-specific and optional
+- It follows familiar class extension patterns
+- Clear documentation about when to use each approach
+- Eslint and Glint tooling can reduce the switching costs (which we probably want anyway for our existing component format switching)
+
+## Alternatives
+
+n/a
+
+## Unresolved questions
+
+n/a


### PR DESCRIPTION
<!-- If you are proposing a new RFC, please fill out the below template. 
If not, please remove the below contents
-->

# Propose Template Only Class Components

<!-- Update the below to link to the rendered version of your RFC. 
The URL can be interpolated below or can be found by going to the files tab
and choosing `View file' from the `...' menu in the right hand corner of the file. -->

## [Rendered](https://github.com/{{username}}/rfcs/blob/{{branch}}/text/{{rfc_number}}-{{rfc_slug}}.md)

## Summary

This pull request is proposing a new RFC.

To succeed, it will need to pass into the [Exploring Stage](https://github.com/emberjs/rfcs#exploring), followed by the [Accepted Stage](https://github.com/emberjs/rfcs#accepted).

A Proposed or Exploring RFC may also move to the [Closed Stage](https://github.com/emberjs/rfcs#closed) if it is withdrawn by the author or if it is rejected by the Ember team. This requires an "FCP to Close" period.

**An FCP is required before merging this PR to advance to Accepted.**

Upon merging this PR, automation will open a draft PR for this RFC to move to the [Ready for Released Stage](https://github.com/emberjs/rfcs#ready-for-release).

<details>
  <summary>Exploring Stage Description</summary>

This stage is entered when the Ember team believes the concept described in the RFC should be pursued, but the RFC may still need some more work, discussion, answers to open questions, and/or a champion before it can move to the next stage.

An RFC is moved into Exploring with consensus of the relevant teams. The relevant team expects to spend time helping to refine the proposal. The RFC remains a PR and will have an `Exploring` label applied.

An Exploring RFC that is successfully completed can move to [Accepted](https://github.com/emberjs/rfcs#accepted) with an FCP is required as in the existing process. It may also be moved to [Closed](https://github.com/emberjs/rfcs#closed) with an FCP.
</details>

<details>
  <summary>Accepted Stage Description</summary>

To move into the "accepted stage" the RFC must have complete prose and have successfully passed through an "FCP to Accept" period in which the community has weighed in and consensus has been achieved on the direction. The relevant teams believe that the proposal is well-specified and ready for implementation. The RFC has a champion within one of the relevant teams.

If there are unanswered questions, we have outlined them and expect that they will be answered before [Ready for Release](https://github.com/emberjs/rfcs#ready-for-release). 

When the RFC is accepted, the PR will be merged, and automation will open a new PR to move the RFC to the [Ready for Release](https://github.com/emberjs/rfcs#ready-for-release) stage. That PR should be used to track implementation progress and gain consensus to move to the next stage.

</details>

## Checklist to move to Exploring

- [ ] The team believes the concepts described in the RFC should be pursued.
- [ ] The label `S-Proposed` is removed from the PR and the label `S-Exploring` is added. 
- [ ] The Ember team is willing to work on the proposal to get it to Accepted

## Checklist to move to Accepted

- [ ] This PR has had the `Final Comment Period` label has been added to start the FCP
- [ ] The RFC is announced in #news-and-announcements in the Ember Discord.
- [ ] The RFC has complete prose, is well-specified and ready for implementation.
  - [ ] All sections of the RFC are filled out.
  - [ ] Any unanswered questions are outlined and expected to be answered before Ready for Release.
  - [ ] "How we teach this?" is sufficiently filled out.
- [ ] The RFC has a champion within one of the relevant teams.
- [ ] The RFC has consensus after the FCP period.
