### PR TITLE
Clarify truthiness definitions in logical operators

### DIFF
--- a/text/0562-add-logical-operators.md
+++ b/text/0562-add-logical-operators.md
@@ -42,29 +42,17 @@ Add `{{and}}`, `{{or}}` and `{{not}}` helpers.
 
 #### `{{and}}`
 Takes at least two positional arguments. Raises an error if invoked with less than two arguments.
-It evaluates arguments left to right, returning the first one that is not _truthy_ (**by handlebar's definition of truthiness**)
+It evaluates arguments left to right, returning the first one that is not _truthy_ (**by javascript's definition of truthiness**)
 or the right-most arguments if **all** evaluate to _truthy_.
-This is *NOT* equivalent to the `{{and}}` helper from `ember-truth-helpers` because unlike this proposed helper, the one in `ember-truth-helpers`
-uses Javascript's definition of truthiness.
 
 #### `{{or}}`
 Takes at least two positional arguments. Raises an error if invoked with less than two arguments.
-It evaluates arguments left to right, returning the first one that is _truthy_ (**by handlebar's definition of truthiness**) or the
+It evaluates arguments left to right, returning the first one that is _truthy_ (**by javascript's definition of truthiness**) or the
 right-most argument if all evaluate to _falsy_.
-This is *NOT* equivalent to the `{{or}}` helper from `ember-truth-helpers` because unlike this proposed helper, the one in `ember-truth-helpers`
-uses Javascript's definition of truthiness.
 
 #### `{{not}}`
 Unary operator. Raises an error if invoked with more than one positional argument. If the given value evaluates to a _truthy_ value (**by handlebar's definition of truthiness**),
-the `false` is returned. If the given value evaluates to a _falsy_ value (**by handlebar's definition of truthiness**) then it returns `true`.
-This is *NOT* equivalent to the `{{not}}` helper from `ember-truth-helpers` because unlike this proposed helper, the one in `ember-truth-helpers`
-uses Javascript's definition of truthiness.
-
-#### Handlebar's definition of truthiness
-This is the most important detail of this proposal because it's where it deviates from `ember-truth-helpers`.
-Handlebars has its own definition of _truthyness_, which is similar to Javascripts except that empty arrays are
-considered **falsy**, while in JS are considered **truthy**.
-
+the `false` is returned. If the given value evaluates to a _falsy_ value (**by javascript's definition of truthiness**) then it returns `true`.
 
 This RFC intentionally leaves the implementation details unspecified, but one can think of those helpers as macros that
 expand to combinations of `if`s.


### PR DESCRIPTION
Been doing some pondering as implementing 
- https://github.com/emberjs/ember.js/pull/21337
- https://github.com/emberjs/rfcs/pull/562


The RFC was originally written under an assumption that ember-truth-helpers used a JavaScript definition of truthiness, and _wanted_ to use a handlebars definition of truthiness.


It's worth bringing this up again because:
- ember-truth-helpers implemented handlebars truthiness: https://github.com/jmurphyau/ember-truth-helpers/blob/463f748d39d245fbbb2f3555a78a01b31e607a92/src/utils/truth-convert.ts#L85 (and a TS-way to ensure things are narrowed)
- we are only implementing these helpers in strict mode, so we don't need to worry about overriding behavior, and can let existing implementations shadow



However, `if` and `unless` are still using handlebars truthiness, and their behavior is a good argument for keeping the RFC as is.

_And_, TS can and does represent handlebars semantics now https://github.com/jmurphyau/ember-truth-helpers/blob/master/type-tests/utils/truth-convert.test.ts 



Other discussions from the past:


- previous discussion on changing all of truthiness: https://github.com/emberjs/rfcs/pull/861/changes
  - this RFC does not actually propose a migration plan 
- "handlebars truthiness ... design mistake" https://github.com/snewcomer/glimmer-vm/pull/3#discussion_r1017662590



> [!IMPORTANT]
> I think we should keep the RFC as-is, and keep handlebars truthiness semantics. Because we can't really have some utils be one kind of truthy and if/unless be another kind