### PR TITLE
Declare RFC 669 (tracked storage polyfill) as discontinued

### DIFF
--- a/text/0669-tracked-storage-primitive.md
+++ b/text/0669-tracked-storage-primitive.md
@@ -7,7 +7,7 @@ teams:
   - framework
 prs:
   accepted: https://github.com/emberjs/rfcs/pull/669
-  discontinue: https://github.com/emberjs/rfcs/pull/1195
+  discontinued: https://github.com/emberjs/rfcs/pull/1195
 project-link:
 ---
 

--- a/text/0669-tracked-storage-primitive.md
+++ b/text/0669-tracked-storage-primitive.md
@@ -12,6 +12,9 @@ project-link:
 
 # Tracked Storage Primitives
 
+> [!IMPORTANT]
+> This RFC has been abandoned, because of the unergonomic APIs it suggested, and this RFC (in use case) has been replaced with [RFC#1071](https://github.com/emberjs/rfcs/pull/1071)
+
 ## Summary
 
 Provide a low level primitive for storing tracked values:

--- a/text/0669-tracked-storage-primitive.md
+++ b/text/0669-tracked-storage-primitive.md
@@ -7,13 +7,14 @@ teams:
   - framework
 prs:
   accepted: https://github.com/emberjs/rfcs/pull/669
+  discontinue: https://github.com/emberjs/rfcs/pull/1195
 project-link:
 ---
 
 # Tracked Storage Primitives
 
 > [!IMPORTANT]
-> This RFC has been abandoned, because of the unergonomic APIs it suggested, and this RFC (in use case) has been replaced with [RFC#1071](https://github.com/emberjs/rfcs/pull/1071)
+> This RFC has been discontinued, because of the unergonomic APIs it suggested, and this RFC (in use case) has been replaced with [RFC#1071](https://github.com/emberjs/rfcs/pull/1071)
 
 ## Summary
 


### PR DESCRIPTION
perhaps pending: 
- https://github.com/emberjs/rfcs/pull/1071