### PR TITLE
Deprecate "ember component"

### DIFF
--- a/text/1216-deprecate-ember-component.md
+++ b/text/1216-deprecate-ember-component.md
@@ -25,7 +25,7 @@ prs:
 project-link: Leave as is
 -->
 
-# Deprecate `import Component from '@ember/component'`
+# Deprecate Classic Ember Component aka `import Component from '@ember/component'`
 
 ## Summary
 

--- a/text/1216-deprecate-ember-component.md
+++ b/text/1216-deprecate-ember-component.md
@@ -1,0 +1,470 @@
+---
+stage: accepted
+start-date: 2026-07-27T00:00:00.000Z
+release-date:
+release-versions:
+teams:
+  - framework
+  - learning
+  - typescript
+prs:
+  accepted: https://github.com/emberjs/rfcs/pull/1216
+project-link:
+---
+
+<!---
+Directions for above:
+
+stage: Leave as is
+start-date: Fill in with today's date, 2032-12-01T00:00:00.000Z
+release-date: Leave as is
+release-versions: Leave as is
+teams: Include only the [team(s)](README.md#relevant-teams) for which this RFC applies
+prs:
+  accepted: Fill this in with the URL for the Proposal RFC PR
+project-link: Leave as is
+-->
+
+# Deprecate `import Component from '@ember/component'`
+
+## Summary
+
+Deprecate the classic component class -- the default export of `@ember/component`.
+
+Glimmer components ([`@glimmer/component`](https://api.emberjs.com/ember/release/modules/@glimmer%2Fcomponent)) have been the default since Octane (`ember-source@3.15`, 2019), and every feature of the classic component has a replacement that is smaller, easier to teach, and doesn't depend on the classic object model.
+
+## Motivation
+
+Classic components are the largest remaining consumer of everything else we've been deprecating:
+
+- they extend `EmberObject`, requiring the [Classic Class system](https://github.com/emberjs/rfcs/pull/1117)
+- they are assembled out of [Mixins](https://github.com/emberjs/rfcs/pull/1116) (`Evented`, `ActionSupport`, `TargetActionSupport`, ...)
+- they are the last thing in the framework that supports two-way bindings
+- their `click()` / `mouseEnter()` / etc methods require the app-wide `EventDispatcher`, which attaches delegated listeners to the root of every Ember app whether or not anything uses them
+
+**We cannot finish removing the classic object model while the classic component still exists.**
+
+Deleting the classic component (at the major following this deprecation) lets us also delete the `EventDispatcher`, `Ember.View`-era internals, and the component half of the two-way binding system -- some of the oldest and most expensive code in `ember-source`.
+
+## Transition Path
+
+### What is deprecated
+
+Only the _default_ export of `@ember/component`. The module itself and its named exports are unaffected:
+
+|   | export | status |
+| - | ------ | ------ |
+| 🌐 | `default` (the classic `Component` class) | **deprecated** |
+| 🌐 | `setComponentTemplate` | stays |
+| 🌐 | `getComponentTemplate` | stays |
+| 🌐 | `setComponentManager` | stays |
+| 🌐 | `capabilities` | stays |
+| 🌐 | `@ember/component/template-only` | stays |
+
+Since importing a module can't warn at runtime, the deprecation fires when the class is extended (via native `class extends` or `.extend()`) or instantiated:
+
+```js
+deprecate(message, false, {
+  id: 'ember-component',
+  until: '8.0.0',
+  for: 'ember-source',
+  url: 'https://deprecations.emberjs.com/id/ember-component',
+  since: { available: '7.x', enabled: '7.x' }, // exact versions dependent on implementation timing
+});
+```
+
+The built-in components (`<Input>`, `<Textarea>`, `<LinkTo>`) were already moved off the classic component base class in [RFC #671](https://rfcs.emberjs.com/id/0671-modernize-built-in-components-1), so they do not trigger this deprecation.
+
+### Deprecation Guide
+
+The guide leads with what your code should look like when you're done, because folks doing this migration have reported that the hardest part is not any individual step -- it's knowing where they're going. The steps come after.
+
+#### The end state
+
+Each scenario below shows a classic component and what it becomes. The "after" examples use `<template>` ([RFC #779](https://rfcs.emberjs.com/id/0779-first-class-component-templates)), but everything shown also works in loose-mode `.hbs` + `.js` colocation if you haven't adopted gjs/gts yet.
+
+##### You only have a JS file out of habit
+
+```js
+// before: app/components/greeting.js
+import Component from '@ember/component';
+
+export default Component.extend();
+```
+
+```hbs
+{{! before: app/components/greeting.hbs }}
+<p>Hello, {{@name}}!</p>
+```
+
+Delete the class. A template is a component:
+
+```gjs
+// after: app/components/greeting.gjs
+<template>
+  <p>Hello, {{@name}}!</p>
+</template>
+```
+
+##### Local state and actions
+
+```js
+// before
+import Component from '@ember/component';
+import { action } from '@ember/object';
+
+export default class Toggle extends Component {
+  isOn = false;
+
+  @action
+  flip() {
+    this.set('isOn', !this.isOn);
+  }
+}
+```
+
+```gjs
+// after
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
+
+export default class Toggle extends Component {
+  @tracked isOn = false;
+
+  flip = () => (this.isOn = !this.isOn);
+
+  <template>
+    <button type="button" {{on "click" this.flip}}>
+      {{if this.isOn "on" "off"}}
+    </button>
+  </template>
+}
+```
+
+No more `this.set` -- assignment to a `@tracked` property is all there is.
+
+##### The element: `tagName`, `classNames`, `attributeBindings`, `elementId`, `ariaRole`
+
+Classic components conjure a wrapper element out of JS configuration. Glimmer components don't have a wrapper element at all -- whatever element you want, you write in the template, where it was always visible to begin with.
+
+```js
+// before
+import Component from '@ember/component';
+
+export default class UserCard extends Component {
+  tagName = 'section';
+  classNames = ['user-card'];
+  classNameBindings = ['isSelected:selected'];
+  attributeBindings = ['label:aria-label'];
+  ariaRole = 'listitem';
+}
+```
+
+```hbs
+{{! before }}
+<img src={{this.user.avatar}} alt="" />
+{{yield}}
+```
+
+```gjs
+// after
+<template>
+  <section
+    class="user-card {{if @isSelected 'selected'}}"
+    role="listitem"
+    aria-label={{@label}}
+    ...attributes
+  >
+    <img src={{@user.avatar}} alt="" />
+    {{yield}}
+  </section>
+</template>
+```
+
+`...attributes` covers what `class` / `id` / attribute merging from the call site used to do -- and unlike the classic behavior, callers can now target it exactly where you place it.
+
+##### DOM event methods: `click()`, `mouseEnter()`, `keyDown()`, ...
+
+```js
+// before
+import Component from '@ember/component';
+
+export default class Item extends Component {
+  click(event) {
+    this.select(event);
+  }
+}
+```
+
+```gjs
+// after
+import { on } from '@ember/modifier';
+
+<template>
+  <div {{on "click" @select}} ...attributes>
+    {{yield}}
+  </div>
+</template>
+```
+
+The `{{on}}` modifier attaches a real event listener to a real element -- no `EventDispatcher`, no delegation, no guessing which element receives the event.
+
+##### Lifecycle hooks and `this.element`
+
+Anything that needed `didInsertElement` / `didUpdateAttrs` / `willDestroyElement` to touch the DOM becomes a modifier. Modifiers are targeted at the exact element that needs the behavior, and their cleanup is not optional-by-convention -- it's the return value.
+
+```js
+// before
+import Component from '@ember/component';
+
+export default class Chart extends Component {
+  didInsertElement() {
+    super.didInsertElement(...arguments);
+    this.chart = renderChart(this.element, this.data);
+  }
+
+  didUpdateAttrs() {
+    super.didUpdateAttrs(...arguments);
+    this.chart.update(this.data);
+  }
+
+  willDestroyElement() {
+    this.chart.destroy();
+    super.willDestroyElement(...arguments);
+  }
+}
+```
+
+```gjs
+// after
+import { modifier } from 'ember-modifier';
+
+const drawChart = modifier((element, [data]) => {
+  let chart = renderChart(element, data);
+
+  return () => chart.destroy();
+});
+
+<template>
+  <div {{drawChart @data}} ...attributes></div>
+</template>
+```
+
+For non-DOM teardown, `@glimmer/component` still has `willDestroy`, and `registerDestructor` from `@ember/destroyable` works everywhere.
+
+##### `didReceiveAttrs` / computed properties deriving state
+
+Derived data doesn't need a lifecycle hook or a dependent-key list. It's a getter.
+
+```js
+// before
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+
+export default class FullName extends Component {
+  @computed('first', 'last')
+  get fullName() {
+    return `${this.first} ${this.last}`;
+  }
+}
+```
+
+```js
+// after
+import Component from '@glimmer/component';
+
+export default class FullName extends Component {
+  get fullName() {
+    return `${this.args.first} ${this.args.last}`;
+  }
+}
+```
+
+If the getter is expensive, `@cached` (from `@glimmer/tracking`) memoizes it. If the getter is trivial (like this one), you likely don't need the class at all.
+
+##### Two-way bindings
+
+Classic components let a child `this.set()` an argument and have the write propagate into the parent. Glimmer components' `this.args` is read-only: the owner of the state changes it, and the child asks via a callback.
+
+```js
+// before: the child writes the parent's property
+import Component from '@ember/component';
+import { action } from '@ember/object';
+
+export default class Counter extends Component {
+  @action
+  increment() {
+    this.set('count', this.count + 1);
+  }
+}
+```
+
+```gjs
+// after: the parent owns the state, the child receives a function
+// parent
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import Counter from './counter';
+
+export default class Parent extends Component {
+  @tracked count = 0;
+
+  increment = () => this.count++;
+
+  <template>
+    <Counter @count={{this.count}} @onIncrement={{this.increment}} />
+  </template>
+}
+```
+
+##### `positionalParams`
+
+There is no equivalent -- angle bracket invocation has no positional arguments. Give the arguments names:
+
+```hbs
+{{! before }}
+{{avatar user size}}
+```
+
+```hbs
+{{! after }}
+<Avatar @user={{user}} @size={{size}} />
+```
+
+#### Migrating incrementally
+
+You do not need a flag day. Classic and Glimmer components coexist in the same app, the same route, even the same template -- migrate one component at a time, in any order.
+
+Here is the whole path in one picture. Diamonds ask "does your code do this?", rectangles are hand-work, double-walled boxes are codemods that do the work for you. The top section runs once across the whole app; the bottom section repeats for each component, top to bottom:
+
+```mermaid
+flowchart TD
+    Start(["import Component from '@ember/component'"]) --> Colocated
+
+    subgraph once["once, app-wide"]
+        Colocated{"templates in app/templates/components/,<br>or layout / layoutName?"}
+        Migrator[["ember-component-template-colocation-migrator"]]
+        Curlies{"invoked curly-style: {{my-component}}?"}
+        Angle[["ember-angle-brackets-codemod"]]
+        Implicit{"bare {{foo}} in templates instead of<br>{{this.foo}} / {{@foo}}?"}
+        NoImplicit[["ember-no-implicit-this-codemod"]]
+        ClassicClass{"still using .extend()?"}
+        Mixins["deal with Mixins first: inline them, or<br>convert to class decorators (RFC #1116)"]
+        Native[["ember-native-class-codemod"]]
+
+        Colocated -->|yes| Migrator --> Curlies
+        Colocated -->|no| Curlies
+        Curlies -->|yes| Angle --> Implicit
+        Curlies -->|no| Implicit
+        Implicit -->|yes| NoImplicit --> ClassicClass
+        Implicit -->|no| ClassicClass
+        ClassicClass -->|"yes, with Mixins"| Mixins --> Native
+        ClassicClass -->|yes| Native
+    end
+
+    ClassicClass -->|no| Element
+    Native --> Element
+
+    subgraph each["per component, in order -- every step ships on its own, while still classic"]
+        Element{"tagName / classNames / classNameBindings /<br>attributeBindings / elementId / ariaRole?"}
+        Flatten["write the element in the template,<br>move the bindings onto it, add ...attributes,<br>set tagName = ''"]
+        Events{"click() / keyDown() / mouseEnter() / ...?"}
+        On["{{on}} on the element, in the template"]
+        Hooks{"didInsertElement / didUpdateAttrs /<br>willDestroyElement / didRender / this.element?"}
+        Mod["extract a modifier (ember-modifier);<br>@ember/render-modifiers as an intermediate"]
+        TwoWay{"this.set() on passed-in properties,<br>or callers reaching for {{mut}}?"}
+        Ddau["the caller keeps the state and<br>passes a callback down"]
+        Evented{"this.trigger() / this.on() from Evented?"}
+        Cb["plain functions / callbacks (see RFC #1111)"]
+        Derive{"didReceiveAttrs / observers / @computed<br>deriving data?"}
+        Getter["native getters; @cached if expensive"]
+        Local{"local mutable state via this.set()?"}
+        Tracked["@tracked + plain assignment<br>(ember-tracked-properties-codemod)"]
+        Actions{"actions hash / this.send()?"}
+        Methods["@action methods, called directly"]
+        Positional{"positionalParams?"}
+        Named["named arguments, at every call site"]
+
+        Element -->|yes| Flatten --> Events
+        Element -->|no| Events
+        Events -->|yes| On --> Hooks
+        Events -->|no| Hooks
+        Hooks -->|yes| Mod --> TwoWay
+        Hooks -->|no| TwoWay
+        TwoWay -->|yes| Ddau --> Evented
+        TwoWay -->|no| Evented
+        Evented -->|yes| Cb --> Derive
+        Evented -->|no| Derive
+        Derive -->|yes| Getter --> Local
+        Derive -->|no| Local
+        Local -->|yes| Tracked --> Actions
+        Local -->|no| Actions
+        Actions -->|yes| Methods --> Positional
+        Actions -->|no| Positional
+        Positional -->|yes| Named --> Swap
+        Positional -->|no| Swap
+    end
+
+    Swap["swap the superclass:<br>'@ember/component' → '@glimmer/component',<br>this.foo → this.args.foo ({{@foo}} in the template),<br>init() → constructor()"]
+    Gjs{"want template tag / gjs? (RFC #779)"}
+    TT[["@embroider/template-tag-codemod"]]
+    Done(["no more '@ember/component'"])
+
+    Swap --> Gjs
+    Gjs -->|yes| TT --> Done
+    Gjs -->|no| Done
+```
+
+Within a single component, the trick is that almost every step above **works while the component is still classic**. That means each step is a small, shippable PR, and the scary-looking superclass swap is the _last_ and _smallest_ diff, not the first:
+
+1. **Get on native classes first.** If the component is still `Component.extend({ ... })`, run [ember-native-class-codemod](https://github.com/ember-codemods/ember-native-class-codemod). Everything below assumes native class syntax.
+2. **Flatten the element into the template.** Write the root element explicitly in the template, move `classNames` / `classNameBindings` / `attributeBindings` / `ariaRole` onto it, add `...attributes`, then set `tagName = ''`. Classic components fully support `tagName: ''` + splattributes, so this ships on its own.
+3. **Replace event methods with `{{on}}`.** Once the element is in the template, `click()` becomes `{{on "click" this.select}}` on that element. Also shippable while classic.
+4. **Move lifecycle hooks into modifiers.** [@ember/render-modifiers](https://github.com/emberjs/ember-render-modifiers) (`{{did-insert}}` / `{{did-update}}` / `{{will-destroy}}`) is the mechanical intermediate step; a purpose-built [ember-modifier](https://github.com/ember-modifier/ember-modifier) is the end state. Modifiers work on classic components' templates too.
+5. **Untangle two-way bindings.** Stop `this.set()`-ing anything that was passed in; take a callback argument instead. This is the only step that changes the component's public interface, so it's the one to review carefully.
+6. **Replace `@computed` with getters and local state with `@tracked`.** Tracked properties work inside classic components, so this also ships independently.
+7. **Swap the superclass.** `import Component from '@ember/component'` → `import Component from '@glimmer/component'`, and argument access moves from `this.foo` to `this.args.foo` (`{{@foo}}` in the template). Because of steps 2--6, there is nothing else left in the class that needs to change.
+8. **(Optional) convert to `<template>`.** See [RFC #779](https://rfcs.emberjs.com/id/0779-first-class-component-templates).
+
+There is deliberately no single classic→glimmer codemod: steps 2, 4, and 5 involve decisions (where does `...attributes` go? what is the modifier's responsibility? who owns this state?) that a codemod would get wrong silently. The mechanical parts are covered:
+
+- [ember-component-template-colocation-migrator](https://github.com/ember-codemods/ember-component-template-colocation-migrator)
+- [ember-angle-brackets-codemod](https://github.com/ember-codemods/ember-angle-brackets-codemod)
+- [ember-no-implicit-this-codemod](https://github.com/ember-codemods/ember-no-implicit-this-codemod)
+- [ember-native-class-codemod](https://github.com/ember-codemods/ember-native-class-codemod)
+- [ember-tracked-properties-codemod](https://github.com/ember-codemods/ember-tracked-properties-codemod)
+- [@embroider/template-tag-codemod](https://github.com/embroider-build/embroider/tree/main/packages/template-tag-codemod)
+
+### Ecosystem
+
+- `eslint-plugin-ember` already has [`ember/no-classic-components`](https://github.com/ember-cli/eslint-plugin-ember/blob/main/docs/rules/no-classic-components.md) in its recommended config, so most apps have been told about this for years.
+- The component blueprint has generated Glimmer components since Octane; no blueprint changes needed.
+- Addons that ship classic components will need to migrate before the next major. Per usual, addon authors are expected to move faster than app authors, and the deprecation window exists for exactly this.
+- Ember Inspector renders both component systems today; removal (at the major) only deletes code paths.
+- SSR / Fastboot: no impact beyond the components themselves.
+
+## How We Teach This
+
+The guides have not taught classic components since Octane -- there is nothing to remove from the current guides. The work is:
+
+- publish the deprecation guide above at [deprecations.emberjs.com](https://deprecations.emberjs.com)
+- mark the class deprecated in the API docs, linking to the guide
+- the [Octane vs Classic cheat sheet](https://guides.emberjs.com/release/upgrading/current-edition/) already covers most of these before/afters and should be linked from the deprecation message
+
+## Drawbacks
+
+This is the big one. Every long-lived Ember app has classic components, and unlike `inject`-vs-`service` there is no find-and-replace -- each component takes actual thought. Apps with hundreds of classic components will feel this deprecation more than any since Octane shipped.
+
+The mitigations are that the deprecation window is long, every intermediate step is shippable on its own (see above), and the replacement has been the default -- with documentation, lint rules, and community experience -- for over six years.
+
+## Alternatives
+
+- do nothing -- we keep shipping the `EventDispatcher`, the classic class machinery, and two-way bindings to every app forever, and [#1116](https://github.com/emberjs/rfcs/pull/1116)/[#1117](https://github.com/emberjs/rfcs/pull/1117) can never complete their removals.
+- extract the classic component into a userland package -- `setComponentManager` exists, so a `classic-component` package with its own component manager is _technically_ possible, and would give stuck apps an escape hatch past the major. This is compatible with (not an alternative to) this RFC, and could be community-maintained the way [ember-legacy-built-in-components](https://github.com/emberjs/ember-legacy-built-in-components) was for RFC #671. Notably though, such a package could not support the `click()`-style event methods without shipping its own event dispatcher.
+- deprecate only pieces (e.g. just the event methods, just two-way bindings) -- slices the same work into more RFCs and more deprecation cycles without changing the destination.
+
+## Unresolved questions
+
+- Should `@ember/component/template-only` be deprecated alongside this? `<template>` makes it unnecessary, but plenty of v2 addons use it in their compiled output, so it likely wants its own RFC and timeline.
+- Exact `until` / `since` versions depend on which release the deprecation lands in.

--- a/text/1216-deprecate-ember-component.md
+++ b/text/1216-deprecate-ember-component.md
@@ -76,7 +76,6 @@ deprecate(message, false, {
 });
 ```
 
-The built-in components (`<Input>`, `<Textarea>`, `<LinkTo>`) were already moved off the classic component base class in [RFC #671](https://rfcs.emberjs.com/id/0671-modernize-built-in-components-1), so they do not trigger this deprecation.
 
 ### Deprecation Guide
 

--- a/text/1216-deprecate-ember-component.md
+++ b/text/1216-deprecate-ember-component.md
@@ -86,7 +86,7 @@ Each scenario below shows a classic component and what it becomes. The "after" e
 > [!NOTE]
 > gjs / gts is supported back to 3.28, and includes `@ember/component`. This allows very zebra-striped incremental migrations, if needed.
 
-##### You only have a JS file 
+<details><summary>You only have a JS file</summary> 
 
 ```js
 // before: app/components/greeting.js
@@ -109,7 +109,9 @@ Delete the class. A template is a component:
 </template>
 ```
 
-##### Local state and actions
+</details>
+
+<details><summary>Local state and actions</summary>
 
 ```js
 // before
@@ -147,7 +149,9 @@ export default class Toggle extends Component {
 
 `this.set` becomes plain assignment to a `@tracked` property.
 
-##### The element: `tagName`, `classNames`, `attributeBindings`, `elementId`, `ariaRole`
+</details>
+
+<details><summary>The element: <code>tagName</code>, <code>classNames</code>, <code>attributeBindings</code>, <code>elementId</code>, <code>ariaRole</code></summary>
 
 Glimmer components have no wrapper element. Write the element in the template, and move each JS setting onto it as an attribute:
 
@@ -187,7 +191,9 @@ export default class UserCard extends Component {
 
 `...attributes` receives the attributes passed at the call site (`class`, `id`, `data-*`, ...); place it on the element that should receive them.
 
-##### DOM event methods: `click()`, `mouseEnter()`, `keyDown()`, ...
+</details>
+
+<details><summary>DOM event methods: <code>click()</code>, <code>mouseEnter()</code>, <code>keyDown()</code>, ...</summary>
 
 ```js
 // before
@@ -213,7 +219,9 @@ import { on } from '@ember/modifier';
 
 Each event method maps to `{{on}}` with the DOM event name: `click()` → `{{on "click" ...}}`, `keyDown()` → `{{on "keydown" ...}}`, `mouseEnter()` → `{{on "mouseenter" ...}}`.
 
-##### Lifecycle hooks and `this.element`
+</details>
+
+<details><summary>Lifecycle hooks and <code>this.element</code></summary>
 
 Anything that used `didInsertElement` / `didUpdateAttrs` / `willDestroyElement` to touch the DOM becomes a modifier, attached to the element it manages. Teardown is the modifier's return value.
 
@@ -256,7 +264,9 @@ const drawChart = modifier((element, [data]) => {
 
 For non-DOM teardown, `@glimmer/component` still has `willDestroy`, and `registerDestructor` from `@ember/destroyable` works everywhere.
 
-##### `didReceiveAttrs` / computed properties deriving state
+</details>
+
+<details><summary><code>didReceiveAttrs</code> / computed properties deriving state</summary>
 
 Derived data becomes a getter:
 
@@ -286,7 +296,9 @@ export default class FullName extends Component {
 
 If the getter is expensive, `@cached` (from `@glimmer/tracking`) memoizes it. If the getter only formats arguments (like this one), skip the class and put the expression in a template-only component.
 
-##### Two-way bindings
+</details>
+
+<details><summary>Two-way bindings</summary>
 
 Classic components let a child `this.set()` an argument and have the write propagate into the parent. Glimmer components' `this.args` is read-only: the owner of the state changes it, and the child asks via a callback.
 
@@ -321,7 +333,9 @@ export default class Parent extends Component {
 }
 ```
 
-##### `positionalParams`
+</details>
+
+<details><summary><code>positionalParams</code></summary>
 
 Angle bracket invocation has no positional arguments. Give the arguments names:
 
@@ -334,6 +348,8 @@ Angle bracket invocation has no positional arguments. Give the arguments names:
 {{! after }}
 <Avatar @user={{user}} @size={{size}} />
 ```
+
+</details>
 
 #### Migrating incrementally
 

--- a/text/1216-deprecate-ember-component.md
+++ b/text/1216-deprecate-ember-component.md
@@ -489,7 +489,7 @@ The guides have not taught classic components since Octane -- there is nothing t
 
 ## Drawbacks
 
-This is the big one. Every long-lived Ember app has classic components, and unlike `inject`-vs-`service` there is no find-and-replace -- each component takes actual thought. Apps with hundreds of classic components will feel this deprecation more than any since Octane shipped.
+Every long-lived Ember app has classic components, and unlike `inject`-vs-`service` there is no find-and-replace -- each component takes actual thought.
 
 The mitigations are that the deprecation window is long, every intermediate step is shippable on its own (see above), and the replacement has been the default -- with documentation, lint rules, and community experience -- for over six years.
 

--- a/text/1216-deprecate-ember-component.md
+++ b/text/1216-deprecate-ember-component.md
@@ -426,6 +426,7 @@ Longer walkthroughs of the same migration:
 - the Ember Atlas recommended migration order (preserved in [Melanie Sumner's slides](https://noti.st/melsumner/Hl16PZ/slides)) -- source of "observers go before `@tracked`"
 - community walkthroughs from [Lighthouse](https://dev.to/lighthouse-intelligence/the-road-from-ember-classic-to-glimmer-components-4hlc) and [Isaac Lee](https://crunchingnumbers.live/2019/12/23/rewriting-apps-in-ember-octane/)
 
+In no particular order:
 
 - **Get on native classes.**
     - codemod: [ember-native-class-codemod](https://github.com/ember-codemods/ember-native-class-codemod)

--- a/text/1216-deprecate-ember-component.md
+++ b/text/1216-deprecate-ember-component.md
@@ -77,12 +77,6 @@ The built-in components (`<Input>`, `<Textarea>`, `<LinkTo>`) were already moved
 
 ### Deprecation Guide
 
-The end state for each classic component feature comes first; the migration steps come after.
-
-#### The end state
-
-Each scenario below shows a classic component and what it becomes. The "after" examples use `<template>` ([RFC #779](https://rfcs.emberjs.com/id/0779-first-class-component-templates)), but everything shown also works in loose-mode `.hbs` + `.js` colocation if you haven't adopted gjs/gts yet.
-
 > [!NOTE]
 > gjs / gts is supported back to 3.28, and includes `@ember/component`. This allows very zebra-striped incremental migrations, if needed.
 
@@ -424,16 +418,41 @@ Longer walkthroughs of the same migration:
 - the Ember Atlas recommended migration order (preserved in [Melanie Sumner's slides](https://noti.st/melsumner/Hl16PZ/slides)) -- source of "observers go before `@tracked`"
 - community walkthroughs from [Lighthouse](https://dev.to/lighthouse-intelligence/the-road-from-ember-classic-to-glimmer-components-4hlc) and [Isaac Lee](https://crunchingnumbers.live/2019/12/23/rewriting-apps-in-ember-octane/)
 
-Every step below except the swap itself works while the component is still classic, so each one is a small, shippable PR. The numbering is a sensible default, not a dependency list -- the only hard edges are that the element has to be in the template (step 2) before anything can attach to it (steps 3 and 4), and that everything classic-only has to be gone before the swap (step 7):
+Every step ships on its own, while the component is still classic. The numbering is a sensible default, not a dependency list. The only hard edges:
 
-1. **Get on native classes first.** If the component is still `Component.extend({ ... })`, run [ember-native-class-codemod](https://github.com/ember-codemods/ember-native-class-codemod). Everything below assumes native class syntax.
-2. **Flatten the element into the template.** Write the root element explicitly in the template, move `classNames` / `classNameBindings` / `attributeBindings` / `ariaRole` onto it, add `...attributes`, then set `tagName = ''`. Classic components fully support `tagName: ''` + splattributes, so this ships on its own.
-3. **Replace event methods with `{{on}}`.** Once the element is in the template, `click()` becomes `{{on "click" this.select}}` on that element. Also shippable while classic.
-4. **Move lifecycle hooks into modifiers.** [@ember/render-modifiers](https://github.com/emberjs/ember-render-modifiers) (`{{did-insert}}` / `{{did-update}}` / `{{will-destroy}}`) is the mechanical intermediate step; a purpose-built [ember-modifier](https://github.com/ember-modifier/ember-modifier) is the end state. Modifiers work on classic components' templates too.
-5. **Untangle two-way bindings.** Stop `this.set()`-ing anything that was passed in; take a callback argument instead. This is the only step that changes the component's public interface, so it's the one to review carefully.
-6. **Replace `@computed` with getters.** Getters work inside classic components, so this also ships independently. If the component has observers, remove those first: observers do not fire for `@tracked` updates, so they have to be gone before anything they watch becomes tracked.
-7. **Swap the superclass, and adopt `@tracked` in the same pass.** `import Component from '@ember/component'` → `import Component from '@glimmer/component'`, argument access moves from `this.foo` to `this.args.foo` (`{{@foo}}` in the template), `init()` becomes `constructor()`, and local mutable state becomes `@tracked` with plain assignment ([ember-tracked-properties-codemod](https://github.com/ember-codemods/ember-tracked-properties-codemod) handles the mechanical part). Go leaves-first across the app, since a computed property in a not-yet-converted parent cannot depend on this component's new native getters. After steps 2--6, nothing else in the class needs to change.
-8. **(Optional) convert to `<template>`.** See [RFC #779](https://rfcs.emberjs.com/id/0779-first-class-component-templates). [@embroider/template-tag-codemod](https://github.com/embroider-build/embroider/tree/main/packages/template-tag-codemod) does this mechanically; it skips any component that is not yet colocated and on native class syntax. `<template>` works with classic components (it compiles to `setComponentTemplate(...)`), so this step is available any time after step 1 -- it does not have to wait for the superclass swap.
+- step 2 before steps 3 and 4 (the element has to exist in the template before things can attach to it)
+- everything before step 7 (the swap)
+
+1. **Get on native classes.**
+    - still `Component.extend({ ... })`? run [ember-native-class-codemod](https://github.com/ember-codemods/ember-native-class-codemod)
+    - everything below assumes native class syntax
+2. **Flatten the element into the template.**
+    - write the root element in the template
+    - move `classNames` / `classNameBindings` / `attributeBindings` / `ariaRole` onto it
+    - add `...attributes`
+    - set `tagName = ''` (classic components fully support `tagName: ''` + splattributes)
+3. **Replace event methods with `{{on}}`.**
+    - `click()` → `{{on "click" this.select}}` on the element from step 2
+4. **Move lifecycle hooks into modifiers.**
+    - end state: a purpose-built [ember-modifier](https://github.com/ember-modifier/ember-modifier)
+    - optional intermediate: [@ember/render-modifiers](https://github.com/emberjs/ember-render-modifiers) (`{{did-insert}}` / `{{did-update}}` / `{{will-destroy}}`) -- a migration tool only, not recommended for applications (see its README); skippable entirely
+    - modifiers work on classic components' templates too
+5. **Untangle two-way bindings.**
+    - stop `this.set()`-ing anything that was passed in; take a callback argument instead
+    - the only step that changes the component's public interface -- review carefully
+6. **Replace `@computed` with getters.**
+    - getters work inside classic components
+    - observers first: they do not fire for `@tracked` updates, so remove them before anything they watch becomes tracked
+7. **Swap the superclass, and adopt `@tracked` in the same pass.**
+    - `import Component from '@ember/component'` → `import Component from '@glimmer/component'`
+    - `this.foo` → `this.args.foo` (`{{@foo}}` in the template)
+    - `init()` → `constructor()`
+    - local mutable state → `@tracked` with plain assignment ([ember-tracked-properties-codemod](https://github.com/ember-codemods/ember-tracked-properties-codemod))
+    - go leaves-first: a computed property in a not-yet-converted parent cannot depend on this component's new native getters
+    - after steps 2--6, nothing else in the class needs to change
+8. **(Optional) convert to `<template>`.** ([RFC #779](https://rfcs.emberjs.com/id/0779-first-class-component-templates))
+    - [@embroider/template-tag-codemod](https://github.com/embroider-build/embroider/tree/main/packages/template-tag-codemod) does it mechanically; it skips components that are not colocated + native-class
+    - works with classic components (`<template>` compiles to `setComponentTemplate(...)`), so this is available any time after step 1 -- no need to wait for the swap
 
 There is no single classic→glimmer codemod; steps 2, 4, and 5 require per-component decisions. The mechanical parts are covered by:
 

--- a/text/1216-deprecate-ember-component.md
+++ b/text/1216-deprecate-ember-component.md
@@ -499,5 +499,4 @@ The mitigations are that the deprecation window is long, every intermediate step
 
 ## Unresolved questions
 
-- Should `@ember/component/template-only` be deprecated alongside this? `<template>` makes it unnecessary, but plenty of v2 addons use it in their compiled output, so it likely wants its own RFC and timeline.
-- Exact `until` / `since` versions depend on which release the deprecation lands in.
+n/a

--- a/text/1216-deprecate-ember-component.md
+++ b/text/1216-deprecate-ember-component.md
@@ -349,58 +349,64 @@ Angle bracket invocation has no positional arguments. Give the arguments names:
 
 You do not need a flag day. Classic and Glimmer components coexist in the same app, the same route, even the same template -- migrate one component at a time, in any order.
 
-Here is the whole path in one picture. Diamonds ask "does your code do this?" -- a "no" means there is nothing to do on that track. Rectangles are hand-work, double-walled boxes are codemods that do the work for you. Anything side-by-side is genuinely independent: do it in any order, or in parallel across a team. The only arrows that mean "must happen first" are the ones you see:
+Here is the whole path in one picture. Diamonds ask "does your code do this?" -- a "no" means there is nothing to do on that branch. Rectangles are hand-work, double-walled boxes are codemods that do the work for you. When several branches leave the same node, they are independent: do them in any order, or in parallel across a team. The only arrows that mean "must happen first" are the ones you see:
 
 ```mermaid
 flowchart TD
     Start(["import Component from '@ember/component'"])
+    AppWide(["once, app-wide: run whichever apply"])
+    Hub(["then, for each component, leaves first"])
 
-    subgraph once["once, app-wide -- these four are independent of each other"]
-        Colocated{"templates in app/templates/components/,<br>or layout / layoutName?"} -->|yes| Migrator[["ember-component-template-colocation-migrator"]]
-        Curlies{"invoked curly-style:<br>{{my-component}}?"} -->|yes| Angle[["ember-angle-brackets-codemod"]]
-        Implicit{"bare {{foo}} in templates instead of<br>{{this.foo}} / {{@foo}}?"} -->|yes| NoImplicit[["ember-no-implicit-this-codemod"]]
-        ClassicClass{"still using .extend()?"} -->|"yes, with Mixins"| Mixins["deal with Mixins first: inline them, or<br>convert to class decorators (RFC #1116)"]
-        Mixins --> Native[["ember-native-class-codemod"]]
-        ClassicClass -->|yes| Native
-    end
+    Start --> AppWide
 
-    Start --> once
-    once --> Hub["then, for each component (leaves first):<br>four tracks, no order between them --<br>work them in parallel if you like"]
+    AppWide --> Colocated{"templates in app/templates/components/,<br>or layout / layoutName?"}
+    AppWide --> Curlies{"invoked curly-style:<br>{{my-component}}?"}
+    AppWide --> Implicit{"bare {{foo}} in templates instead of<br>{{this.foo}} / {{@foo}}?"}
+    AppWide --> ClassicClass{"still using .extend()?"}
 
-    Hub --> el
-    Hub --> data
-    Hub --> derived
-    Hub --> inv
+    Colocated -->|yes| Migrator[["ember-component-template-colocation-migrator"]]
+    Curlies -->|yes| Angle[["ember-angle-brackets-codemod"]]
+    Implicit -->|yes| NoImplicit[["ember-no-implicit-this-codemod"]]
+    ClassicClass -->|"yes, with Mixins"| Mixins["deal with Mixins first: inline them, or<br>convert to class decorators (RFC #1116)"]
+    Mixins --> Native[["ember-native-class-codemod"]]
+    ClassicClass -->|yes| Native
 
-    subgraph el["the element"]
-        Element{"anything on the wrapper element?<br>tagName / classNames / classNameBindings /<br>attributeBindings / elementId / ariaRole,<br>click()-style methods, this.element"} -->|yes| Flatten["write the element in the template,<br>move the bindings onto it, add ...attributes,<br>set tagName = ''"]
-        Flatten --> Events{"click() / keyDown() /<br>mouseEnter() / ...?"}
-        Events -->|yes| On["{{on}} on the element,<br>in the template"]
-        Flatten --> Hooks{"didInsertElement / didUpdateAttrs /<br>willDestroyElement / this.element?"}
-        Hooks -->|yes| Mod["extract a modifier (ember-modifier);<br>@ember/render-modifiers as an intermediate"]
-    end
+    Migrator --> Hub
+    Angle --> Hub
+    NoImplicit --> Hub
+    Native --> Hub
 
-    subgraph data["data flow"]
-        TwoWay{"this.set() on passed-in properties,<br>or callers reaching for {{mut}}?"} -->|yes| Ddau["the caller keeps the state and<br>passes a callback down"]
-        Evented{"this.trigger() / this.on()<br>from Evented?"} -->|yes| Cb["plain functions / callbacks<br>(see RFC #1111)"]
-    end
+    Hub --> Element{"anything on the wrapper element?<br>tagName / classNames / classNameBindings /<br>attributeBindings / elementId / ariaRole,<br>click()-style methods, this.element"}
+    Hub --> TwoWay{"this.set() on passed-in properties,<br>or callers reaching for {{mut}}?"}
+    Hub --> Evented{"this.trigger() / this.on()<br>from Evented?"}
+    Hub --> Observers{"observers?"}
+    Hub --> Actions{"actions hash /<br>this.send()?"}
+    Hub --> Positional{"positionalParams?"}
 
-    subgraph derived["derived state"]
-        Observers{"observers?"} -->|yes| RmObs["remove them -- observers do not<br>fire for @tracked updates"]
-        RmObs --> Derive{"didReceiveAttrs / @computed<br>deriving data?"}
-        Observers -->|no| Derive
-        Derive -->|yes| Getter["native getters;<br>@cached if expensive"]
-    end
+    Element -->|yes| Flatten["write the element in the template,<br>move the bindings onto it, add ...attributes,<br>set tagName = ''"]
+    Flatten --> Events{"click() / keyDown() /<br>mouseEnter() / ...?"}
+    Events -->|yes| On["{{on}} on the element,<br>in the template"]
+    Flatten --> Hooks{"didInsertElement / didUpdateAttrs /<br>willDestroyElement / this.element?"}
+    Hooks -->|yes| Mod["extract a modifier<br>(ember-modifier)"]
 
-    subgraph inv["invocation + actions"]
-        Actions{"actions hash /<br>this.send()?"} -->|yes| Methods["@action methods,<br>called directly"]
-        Positional{"positionalParams?"} -->|yes| Named["named arguments,<br>at every call site"]
-    end
+    TwoWay -->|yes| Ddau["the caller keeps the state and<br>passes a callback down"]
+    Evented -->|yes| Cb["plain functions / callbacks<br>(see RFC #1111)"]
 
-    el --> Swap
-    data --> Swap
-    derived --> Swap
-    inv --> Swap
+    Observers -->|yes| RmObs["remove them -- observers do not<br>fire for @tracked updates"]
+    RmObs --> Derive{"didReceiveAttrs / @computed<br>deriving data?"}
+    Observers -->|no| Derive
+    Derive -->|yes| Getter["native getters;<br>@cached if expensive"]
+
+    Actions -->|yes| Methods["@action methods,<br>called directly"]
+    Positional -->|yes| Named["named arguments,<br>at every call site"]
+
+    On --> Swap
+    Mod --> Swap
+    Ddau --> Swap
+    Cb --> Swap
+    Getter --> Swap
+    Methods --> Swap
+    Named --> Swap
 
     Swap["one pass, per component: swap '@ember/component' → '@glimmer/component',<br>this.foo → this.args.foo ({{@foo}} in the template), init() → constructor(),<br>and local this.set() state → @tracked (ember-tracked-properties-codemod)"]
     Swap --> Gjs{"want template tag / gjs? (RFC #779)<br>note: does not have to wait for the swap --<br>gjs/gts works with '@ember/component' too,<br>any time after native class syntax + colocation"}

--- a/text/1216-deprecate-ember-component.md
+++ b/text/1216-deprecate-ember-component.md
@@ -349,7 +349,7 @@ Angle bracket invocation has no positional arguments. Give the arguments names:
 
 #### Migrating incrementally
 
-You do not need a flag day. Classic and Glimmer components coexist in the same app, the same route, even the same template -- migrate one component at a time, in any order.
+You do not need to migrate everything all at once. Classic and Glimmer components coexist in the same app, the same route, even the same template -- migrate one component at a time, in any order.
 
 Here is the whole path in one picture. Diamonds ask "does your code do this?" -- a "no" means there is nothing to do on that branch. Rectangles are hand-work, double-walled boxes are codemods that do the work for you. When several branches leave the same node, they are independent: do them in any order, or in parallel across a team. The only arrows that mean "must happen first" are the ones you see:
 

--- a/text/1216-deprecate-ember-component.md
+++ b/text/1216-deprecate-ember-component.md
@@ -47,6 +47,8 @@ Additionally, Classic components are the largest remaining consumer of everythin
 
 Deleting the classic component (at the major following this deprecation) lets us also delete the `EventDispatcher`, `Ember.View`-era internals, and the component half of the two-way binding system -- some of the oldest and most expensive code in `ember-source`.
 
+Removing Classic components can drastically reduce the maintenance and teaching burden of the Framework. 
+
 ## Transition Path
 
 ### What is deprecated

--- a/text/1216-deprecate-ember-component.md
+++ b/text/1216-deprecate-ember-component.md
@@ -77,13 +77,16 @@ The built-in components (`<Input>`, `<Textarea>`, `<LinkTo>`) were already moved
 
 ### Deprecation Guide
 
-The guide leads with what your code should look like when you're done, because folks doing this migration have reported that the hardest part is not any individual step -- it's knowing where they're going. The steps come after.
+The end state for each classic component feature comes first; the migration steps come after.
 
 #### The end state
 
 Each scenario below shows a classic component and what it becomes. The "after" examples use `<template>` ([RFC #779](https://rfcs.emberjs.com/id/0779-first-class-component-templates)), but everything shown also works in loose-mode `.hbs` + `.js` colocation if you haven't adopted gjs/gts yet.
 
-##### You only have a JS file out of habit
+> [!NOTE]
+> gjs / gts is supported back to 3.28, and includes `@ember/component`. This allows very zebra-striped incremental migrations, if needed.
+
+##### You only have a JS file 
 
 ```js
 // before: app/components/greeting.js
@@ -142,11 +145,11 @@ export default class Toggle extends Component {
 }
 ```
 
-No more `this.set` -- assignment to a `@tracked` property is all there is.
+`this.set` becomes plain assignment to a `@tracked` property.
 
 ##### The element: `tagName`, `classNames`, `attributeBindings`, `elementId`, `ariaRole`
 
-Classic components conjure a wrapper element out of JS configuration. Glimmer components don't have a wrapper element at all -- whatever element you want, you write in the template, where it was always visible to begin with.
+Glimmer components have no wrapper element. Write the element in the template, and move each JS setting onto it as an attribute:
 
 ```js
 // before
@@ -182,7 +185,7 @@ export default class UserCard extends Component {
 </template>
 ```
 
-`...attributes` covers what `class` / `id` / attribute merging from the call site used to do -- and unlike the classic behavior, callers can now target it exactly where you place it.
+`...attributes` receives the attributes passed at the call site (`class`, `id`, `data-*`, ...); place it on the element that should receive them.
 
 ##### DOM event methods: `click()`, `mouseEnter()`, `keyDown()`, ...
 
@@ -208,11 +211,11 @@ import { on } from '@ember/modifier';
 </template>
 ```
 
-The `{{on}}` modifier attaches a real event listener to a real element -- no `EventDispatcher`, no delegation, no guessing which element receives the event.
+Each event method maps to `{{on}}` with the DOM event name: `click()` → `{{on "click" ...}}`, `keyDown()` → `{{on "keydown" ...}}`, `mouseEnter()` → `{{on "mouseenter" ...}}`.
 
 ##### Lifecycle hooks and `this.element`
 
-Anything that needed `didInsertElement` / `didUpdateAttrs` / `willDestroyElement` to touch the DOM becomes a modifier. Modifiers are targeted at the exact element that needs the behavior, and their cleanup is not optional-by-convention -- it's the return value.
+Anything that used `didInsertElement` / `didUpdateAttrs` / `willDestroyElement` to touch the DOM becomes a modifier, attached to the element it manages. Teardown is the modifier's return value.
 
 ```js
 // before
@@ -255,7 +258,7 @@ For non-DOM teardown, `@glimmer/component` still has `willDestroy`, and `registe
 
 ##### `didReceiveAttrs` / computed properties deriving state
 
-Derived data doesn't need a lifecycle hook or a dependent-key list. It's a getter.
+Derived data becomes a getter:
 
 ```js
 // before
@@ -281,7 +284,7 @@ export default class FullName extends Component {
 }
 ```
 
-If the getter is expensive, `@cached` (from `@glimmer/tracking`) memoizes it. If the getter is trivial (like this one), you likely don't need the class at all.
+If the getter is expensive, `@cached` (from `@glimmer/tracking`) memoizes it. If the getter only formats arguments (like this one), skip the class and put the expression in a template-only component.
 
 ##### Two-way bindings
 
@@ -320,7 +323,7 @@ export default class Parent extends Component {
 
 ##### `positionalParams`
 
-There is no equivalent -- angle bracket invocation has no positional arguments. Give the arguments names:
+Angle bracket invocation has no positional arguments. Give the arguments names:
 
 ```hbs
 {{! before }}
@@ -396,27 +399,27 @@ flowchart TD
     Gjs -->|no| Done(["no more '@ember/component'"])
 ```
 
-"Leaves first" because computed properties cannot depend on native getters or tracked data without extra annotations -- so convert components that do not feed data into still-unconverted parents, and work your way up the tree. And `@tracked` rides along with the superclass swap rather than getting its own step: both require actually understanding the component's data flow, so pay that cost once.
+"Leaves first": computed properties cannot depend on native getters or tracked data, so convert components that do not feed data into still-unconverted parents, then work up the tree.
 
-None of this is new ground. Folks have been writing up this migration since 2019, and the writeups disagree on ordering precisely because so little of it is load-bearing:
+Longer walkthroughs of the same migration:
 
 - the official [Octane upgrade guide](https://guides.emberjs.com/v5.12.0/upgrading/current-edition/) -- recommends starting with components that have no two-way bindings, computed properties, or observers
-- [Chris Krycho's phased migration guides](https://github.com/chriskrycho/octane-migration-guides), battle-tested on one of the largest Ember apps in existence -- the leaves-first rule and "do `@tracked` with the swap" both come from here, and they are explicit that their ordering exists to minimize how many times you touch each file, not because things break
-- the Ember Atlas recommended migration order (preserved in [Melanie Sumner's slides](https://noti.st/melsumner/Hl16PZ/slides)) -- the source of "observers go before `@tracked`"
-- community walkthroughs like [Lighthouse's](https://dev.to/lighthouse-intelligence/the-road-from-ember-classic-to-glimmer-components-4hlc) (superclass swap dead last, same as this guide) and [Isaac Lee's](https://crunchingnumbers.live/2019/12/23/rewriting-apps-in-ember-octane/) (route by route, with tests gating each step)
+- [Chris Krycho's phased migration guides](https://github.com/chriskrycho/octane-migration-guides) -- source of the leaves-first rule and of doing `@tracked` with the superclass swap
+- the Ember Atlas recommended migration order (preserved in [Melanie Sumner's slides](https://noti.st/melsumner/Hl16PZ/slides)) -- source of "observers go before `@tracked`"
+- community walkthroughs from [Lighthouse](https://dev.to/lighthouse-intelligence/the-road-from-ember-classic-to-glimmer-components-4hlc) and [Isaac Lee](https://crunchingnumbers.live/2019/12/23/rewriting-apps-in-ember-octane/)
 
-Within a single component, the trick is that almost every step above **works while the component is still classic**. That means each step is a small, shippable PR, and the scary-looking superclass swap is the _last_ and _smallest_ diff, not the first. The numbering below is a sensible default, not a dependency list -- the only hard edges are that the element has to be in the template (step 2) before anything can attach to it (steps 3 and 4), and that everything classic-only has to be gone before the swap (step 7):
+Every step below except the swap itself works while the component is still classic, so each one is a small, shippable PR. The numbering is a sensible default, not a dependency list -- the only hard edges are that the element has to be in the template (step 2) before anything can attach to it (steps 3 and 4), and that everything classic-only has to be gone before the swap (step 7):
 
 1. **Get on native classes first.** If the component is still `Component.extend({ ... })`, run [ember-native-class-codemod](https://github.com/ember-codemods/ember-native-class-codemod). Everything below assumes native class syntax.
 2. **Flatten the element into the template.** Write the root element explicitly in the template, move `classNames` / `classNameBindings` / `attributeBindings` / `ariaRole` onto it, add `...attributes`, then set `tagName = ''`. Classic components fully support `tagName: ''` + splattributes, so this ships on its own.
 3. **Replace event methods with `{{on}}`.** Once the element is in the template, `click()` becomes `{{on "click" this.select}}` on that element. Also shippable while classic.
 4. **Move lifecycle hooks into modifiers.** [@ember/render-modifiers](https://github.com/emberjs/ember-render-modifiers) (`{{did-insert}}` / `{{did-update}}` / `{{will-destroy}}`) is the mechanical intermediate step; a purpose-built [ember-modifier](https://github.com/ember-modifier/ember-modifier) is the end state. Modifiers work on classic components' templates too.
 5. **Untangle two-way bindings.** Stop `this.set()`-ing anything that was passed in; take a callback argument instead. This is the only step that changes the component's public interface, so it's the one to review carefully.
-6. **Replace `@computed` with getters.** Getters work inside classic components, so this also ships independently. If the component has observers, remove those first -- observers do not fire for `@tracked` updates, so they have to be gone before anything they watch becomes tracked.
-7. **Swap the superclass, and adopt `@tracked` in the same pass.** `import Component from '@ember/component'` → `import Component from '@glimmer/component'`, argument access moves from `this.foo` to `this.args.foo` (`{{@foo}}` in the template), `init()` becomes `constructor()`, and local mutable state becomes `@tracked` with plain assignment ([ember-tracked-properties-codemod](https://github.com/ember-codemods/ember-tracked-properties-codemod) handles the mechanical part). These travel together because both require understanding the component's data flow -- understand it once. Go leaves-first across the app, since a computed property in a not-yet-converted parent cannot depend on this component's new native getters. Because of steps 2--6, there is nothing else left in the class that needs to change.
-8. **(Optional) convert to `<template>`.** See [RFC #779](https://rfcs.emberjs.com/id/0779-first-class-component-templates). [@embroider/template-tag-codemod](https://github.com/embroider-build/embroider/tree/main/packages/template-tag-codemod) does this mechanically, and (deliberately) skips any component that is not yet colocated and on native class syntax. Those are its only real prerequisites, though -- `<template>` compiles to `setComponentTemplate(...)`, which works on classic components too, so this step is available the moment step 1 is done. It does not have to wait for the superclass swap.
+6. **Replace `@computed` with getters.** Getters work inside classic components, so this also ships independently. If the component has observers, remove those first: observers do not fire for `@tracked` updates, so they have to be gone before anything they watch becomes tracked.
+7. **Swap the superclass, and adopt `@tracked` in the same pass.** `import Component from '@ember/component'` → `import Component from '@glimmer/component'`, argument access moves from `this.foo` to `this.args.foo` (`{{@foo}}` in the template), `init()` becomes `constructor()`, and local mutable state becomes `@tracked` with plain assignment ([ember-tracked-properties-codemod](https://github.com/ember-codemods/ember-tracked-properties-codemod) handles the mechanical part). Go leaves-first across the app, since a computed property in a not-yet-converted parent cannot depend on this component's new native getters. After steps 2--6, nothing else in the class needs to change.
+8. **(Optional) convert to `<template>`.** See [RFC #779](https://rfcs.emberjs.com/id/0779-first-class-component-templates). [@embroider/template-tag-codemod](https://github.com/embroider-build/embroider/tree/main/packages/template-tag-codemod) does this mechanically; it skips any component that is not yet colocated and on native class syntax. `<template>` works with classic components (it compiles to `setComponentTemplate(...)`), so this step is available any time after step 1 -- it does not have to wait for the superclass swap.
 
-There is deliberately no single classic→glimmer codemod: steps 2, 4, and 5 involve decisions (where does `...attributes` go? what is the modifier's responsibility? who owns this state?) that a codemod would get wrong silently. The mechanical parts are covered:
+There is no single classic→glimmer codemod; steps 2, 4, and 5 require per-component decisions. The mechanical parts are covered by:
 
 - [ember-component-template-colocation-migrator](https://github.com/ember-codemods/ember-component-template-colocation-migrator)
 - [ember-angle-brackets-codemod](https://github.com/ember-codemods/ember-angle-brackets-codemod)
@@ -427,7 +430,7 @@ There is deliberately no single classic→glimmer codemod: steps 2, 4, and 5 inv
 
 ### Ecosystem
 
-- `eslint-plugin-ember` already has [`ember/no-classic-components`](https://github.com/ember-cli/eslint-plugin-ember/blob/main/docs/rules/no-classic-components.md) in its recommended config, so most apps have been told about this for years.
+- `eslint-plugin-ember` already has [`ember/no-classic-components`](https://github.com/ember-cli/eslint-plugin-ember/blob/main/docs/rules/no-classic-components.md) in its recommended config.
 - The component blueprint has generated Glimmer components since Octane; no blueprint changes needed.
 - Addons that ship classic components will need to migrate before the next major. Per usual, addon authors are expected to move faster than app authors, and the deprecation window exists for exactly this.
 - Ember Inspector renders both component systems today; removal (at the major) only deletes code paths.

--- a/text/1216-deprecate-ember-component.md
+++ b/text/1216-deprecate-ember-component.md
@@ -34,6 +34,7 @@ Deprecate the classic component class -- the default export of `@ember/component
 Glimmer components ([`@glimmer/component`](https://api.emberjs.com/ember/release/modules/@glimmer%2Fcomponent)) have been the default component in Ember projects since Octane (`ember-source@3.15`, 2019), and every feature of the classic component has a replacement that is smaller, easier to teach, and doesn't depend on the classic object model.
 
 ## Motivation
+Classic Components have been replaced by Glimmer Components. The replacement was introduced nearly a decade ago and made default in 2019. We've known since we began designing Glimmer Components that the Classic Components had serious limitations and were difficult to teach. 
 
 Classic components are the largest remaining consumer of everything else we've been deprecating:
 

--- a/text/1216-deprecate-ember-component.md
+++ b/text/1216-deprecate-ember-component.md
@@ -31,7 +31,7 @@ project-link: Leave as is
 
 Deprecate the classic component class -- the default export of `@ember/component`.
 
-Glimmer components ([`@glimmer/component`](https://api.emberjs.com/ember/release/modules/@glimmer%2Fcomponent)) have been the default since Octane (`ember-source@3.15`, 2019), and every feature of the classic component has a replacement that is smaller, easier to teach, and doesn't depend on the classic object model.
+Glimmer components ([`@glimmer/component`](https://api.emberjs.com/ember/release/modules/@glimmer%2Fcomponent)) have been the default component in Ember projects since Octane (`ember-source@3.15`, 2019), and every feature of the classic component has a replacement that is smaller, easier to teach, and doesn't depend on the classic object model.
 
 ## Motivation
 

--- a/text/1216-deprecate-ember-component.md
+++ b/text/1216-deprecate-ember-component.md
@@ -390,13 +390,20 @@ flowchart TD
     inv --> Swap
 
     Swap["one pass, per component: swap '@ember/component' → '@glimmer/component',<br>this.foo → this.args.foo ({{@foo}} in the template), init() → constructor(),<br>and local this.set() state → @tracked (ember-tracked-properties-codemod)"]
-    Swap --> Gjs{"want template tag / gjs?<br>(RFC #779)"}
-    Gjs -->|yes| TT[["@embroider/template-tag-codemod<br>(skips components that are not<br>colocated + native-class)"]]
+    Swap --> Gjs{"want template tag / gjs? (RFC #779)<br>note: does not have to wait for the swap --<br>gjs/gts works with '@ember/component' too,<br>any time after native class syntax + colocation"}
+    Gjs -->|yes| TT[["@embroider/template-tag-codemod<br>(only needs colocation +<br>native class syntax)"]]
     TT --> Done
     Gjs -->|no| Done(["no more '@ember/component'"])
 ```
 
-"Leaves first" because computed properties cannot depend on native getters or tracked data without extra annotations -- so convert components that do not feed data into still-unconverted parents, and work your way up the tree. And `@tracked` rides along with the superclass swap rather than getting its own step: both require actually understanding the component's data flow, so pay that cost once. Both of these come straight from [LinkedIn's migration guides](https://github.com/chriskrycho/octane-migration-guides), which are the most battle-tested writeup of this migration -- they note their ordering exists to minimize how many times you touch each file, not because things break.
+"Leaves first" because computed properties cannot depend on native getters or tracked data without extra annotations -- so convert components that do not feed data into still-unconverted parents, and work your way up the tree. And `@tracked` rides along with the superclass swap rather than getting its own step: both require actually understanding the component's data flow, so pay that cost once.
+
+None of this is new ground. Folks have been writing up this migration since 2019, and the writeups disagree on ordering precisely because so little of it is load-bearing:
+
+- the official [Octane upgrade guide](https://guides.emberjs.com/v5.12.0/upgrading/current-edition/) -- recommends starting with components that have no two-way bindings, computed properties, or observers
+- [Chris Krycho's phased migration guides](https://github.com/chriskrycho/octane-migration-guides), battle-tested on one of the largest Ember apps in existence -- the leaves-first rule and "do `@tracked` with the swap" both come from here, and they are explicit that their ordering exists to minimize how many times you touch each file, not because things break
+- the Ember Atlas recommended migration order (preserved in [Melanie Sumner's slides](https://noti.st/melsumner/Hl16PZ/slides)) -- the source of "observers go before `@tracked`"
+- community walkthroughs like [Lighthouse's](https://dev.to/lighthouse-intelligence/the-road-from-ember-classic-to-glimmer-components-4hlc) (superclass swap dead last, same as this guide) and [Isaac Lee's](https://crunchingnumbers.live/2019/12/23/rewriting-apps-in-ember-octane/) (route by route, with tests gating each step)
 
 Within a single component, the trick is that almost every step above **works while the component is still classic**. That means each step is a small, shippable PR, and the scary-looking superclass swap is the _last_ and _smallest_ diff, not the first. The numbering below is a sensible default, not a dependency list -- the only hard edges are that the element has to be in the template (step 2) before anything can attach to it (steps 3 and 4), and that everything classic-only has to be gone before the swap (step 7):
 
@@ -407,7 +414,7 @@ Within a single component, the trick is that almost every step above **works whi
 5. **Untangle two-way bindings.** Stop `this.set()`-ing anything that was passed in; take a callback argument instead. This is the only step that changes the component's public interface, so it's the one to review carefully.
 6. **Replace `@computed` with getters.** Getters work inside classic components, so this also ships independently. If the component has observers, remove those first -- observers do not fire for `@tracked` updates, so they have to be gone before anything they watch becomes tracked.
 7. **Swap the superclass, and adopt `@tracked` in the same pass.** `import Component from '@ember/component'` → `import Component from '@glimmer/component'`, argument access moves from `this.foo` to `this.args.foo` (`{{@foo}}` in the template), `init()` becomes `constructor()`, and local mutable state becomes `@tracked` with plain assignment ([ember-tracked-properties-codemod](https://github.com/ember-codemods/ember-tracked-properties-codemod) handles the mechanical part). These travel together because both require understanding the component's data flow -- understand it once. Go leaves-first across the app, since a computed property in a not-yet-converted parent cannot depend on this component's new native getters. Because of steps 2--6, there is nothing else left in the class that needs to change.
-8. **(Optional) convert to `<template>`.** See [RFC #779](https://rfcs.emberjs.com/id/0779-first-class-component-templates). [@embroider/template-tag-codemod](https://github.com/embroider-build/embroider/tree/main/packages/template-tag-codemod) does this mechanically, and (deliberately) skips any component that is not yet colocated and on native class syntax.
+8. **(Optional) convert to `<template>`.** See [RFC #779](https://rfcs.emberjs.com/id/0779-first-class-component-templates). [@embroider/template-tag-codemod](https://github.com/embroider-build/embroider/tree/main/packages/template-tag-codemod) does this mechanically, and (deliberately) skips any component that is not yet colocated and on native class syntax. Those are its only real prerequisites, though -- `<template>` compiles to `setComponentTemplate(...)`, which works on classic components too, so this step is available the moment step 1 is done. It does not have to wait for the superclass swap.
 
 There is deliberately no single classic→glimmer codemod: steps 2, 4, and 5 involve decisions (where does `...attributes` go? what is the modifier's responsibility? who owns this state?) that a codemod would get wrong silently. The mechanical parts are covered:
 

--- a/text/1216-deprecate-ember-component.md
+++ b/text/1216-deprecate-ember-component.md
@@ -432,35 +432,29 @@ Every step ships on its own, while the component is still classic. The numbering
 - everything before step 7 (the swap)
 
 1. **Get on native classes.**
-    - still `Component.extend({ ... })`? run [ember-native-class-codemod](https://github.com/ember-codemods/ember-native-class-codemod)
-    - everything below assumes native class syntax
-2. **Flatten the element into the template.**
-    - write the root element in the template
-    - move `classNames` / `classNameBindings` / `attributeBindings` / `ariaRole` onto it
-    - add `...attributes`
-    - set `tagName = ''` (classic components fully support `tagName: ''` + splattributes)
-3. **Replace event methods with `{{on}}`.**
-    - `click()` → `{{on "click" this.select}}` on the element from step 2
+    - codemod: [ember-native-class-codemod](https://github.com/ember-codemods/ember-native-class-codemod)
+    - docs: [Native Classes upgrade guide](https://guides.emberjs.com/v5.12.0/upgrading/current-edition/native-classes/)
+2. **Flatten the element into the template**, then set `tagName = ''`.
+    - codemod: [tagless-ember-components-codemod](https://github.com/ember-codemods/tagless-ember-components-codemod)
+    - docs: [Glimmer Components upgrade guide](https://guides.emberjs.com/v5.12.0/upgrading/current-edition/glimmer-components/)
+3. **Replace event methods with `{{on}}`** on the element from step 2.
+    - docs: [`{{on}}` API](https://api.emberjs.com/ember/release/functions/@ember%2Fmodifier/on), [Actions, `{{on}}`, and `{{fn}}` upgrade guide](https://guides.emberjs.com/v5.12.0/upgrading/current-edition/action-on-and-fn/)
 4. **Move lifecycle hooks into modifiers.**
-    - end state: a purpose-built [ember-modifier](https://github.com/ember-modifier/ember-modifier)
-    - optional intermediate: [@ember/render-modifiers](https://github.com/emberjs/ember-render-modifiers) (`{{did-insert}}` / `{{did-update}}` / `{{will-destroy}}`) -- a migration tool only, not recommended for applications (see its README); skippable entirely
-    - modifiers work on classic components' templates too
-5. **Untangle two-way bindings.**
-    - stop `this.set()`-ing anything that was passed in; take a callback argument instead
+    - docs: [Template Lifecycle, DOM, and Modifiers guide](https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifiers/), [ember-modifier](https://github.com/ember-modifier/ember-modifier)
+    - optional intermediate: [@ember/render-modifiers](https://github.com/emberjs/ember-render-modifiers) -- a migration tool only, not recommended for applications (see its README); skippable entirely
+5. **Untangle two-way bindings**: take a callback argument instead.
     - the only step that changes the component's public interface -- review carefully
+    - docs: [Octane vs Classic cheat sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/) (Data Down, Actions Up)
 6. **Replace `@computed` with getters.**
-    - getters work inside classic components
     - observers first: they do not fire for `@tracked` updates, so remove them before anything they watch becomes tracked
+    - docs: [Tracked Properties upgrade guide](https://guides.emberjs.com/v5.12.0/upgrading/current-edition/tracked-properties/)
 7. **Swap the superclass, and adopt `@tracked` in the same pass.**
-    - `import Component from '@ember/component'` → `import Component from '@glimmer/component'`
-    - `this.foo` → `this.args.foo` (`{{@foo}}` in the template)
-    - `init()` → `constructor()`
-    - local mutable state → `@tracked` with plain assignment ([ember-tracked-properties-codemod](https://github.com/ember-codemods/ember-tracked-properties-codemod))
+    - codemod for the `@tracked` part: [ember-tracked-properties-codemod](https://github.com/ember-codemods/ember-tracked-properties-codemod)
+    - docs: [Glimmer Components upgrade guide](https://guides.emberjs.com/v5.12.0/upgrading/current-edition/glimmer-components/) covers the whole conversion (`this.args`, `constructor()`, ...)
     - go leaves-first: a computed property in a not-yet-converted parent cannot depend on this component's new native getters
-    - after steps 2--6, nothing else in the class needs to change
-8. **(Optional) convert to `<template>`.** ([RFC #779](https://rfcs.emberjs.com/id/0779-first-class-component-templates))
-    - [@embroider/template-tag-codemod](https://github.com/embroider-build/embroider/tree/main/packages/template-tag-codemod) does it mechanically; it skips components that are not colocated + native-class
-    - works with classic components (`<template>` compiles to `setComponentTemplate(...)`), so this is available any time after step 1 -- no need to wait for the swap
+8. **(Optional) convert to `<template>`.**
+    - codemod: [@embroider/template-tag-codemod](https://github.com/embroider-build/embroider/tree/main/packages/template-tag-codemod) (requires colocation + native class syntax; works with classic components, so this is available any time after step 1)
+    - docs: [Template Tag Format guide](https://guides.emberjs.com/release/components/template-tag-format/), [RFC #779](https://rfcs.emberjs.com/id/0779-first-class-component-templates)
 
 There is no single classic→glimmer codemod; steps 2, 4, and 5 require per-component decisions. The mechanical parts are covered by:
 
@@ -468,6 +462,7 @@ There is no single classic→glimmer codemod; steps 2, 4, and 5 require per-comp
 - [ember-angle-brackets-codemod](https://github.com/ember-codemods/ember-angle-brackets-codemod)
 - [ember-no-implicit-this-codemod](https://github.com/ember-codemods/ember-no-implicit-this-codemod)
 - [ember-native-class-codemod](https://github.com/ember-codemods/ember-native-class-codemod)
+- [tagless-ember-components-codemod](https://github.com/ember-codemods/tagless-ember-components-codemod)
 - [ember-tracked-properties-codemod](https://github.com/ember-codemods/ember-tracked-properties-codemod)
 - [@embroider/template-tag-codemod](https://github.com/embroider-build/embroider/tree/main/packages/template-tag-codemod)
 

--- a/text/1216-deprecate-ember-component.md
+++ b/text/1216-deprecate-ember-component.md
@@ -36,7 +36,7 @@ Glimmer components ([`@glimmer/component`](https://api.emberjs.com/ember/release
 ## Motivation
 Classic Components have been replaced by Glimmer Components. The replacement was introduced nearly a decade ago and made default in 2019. We've known since we began designing Glimmer Components that the Classic Components had serious limitations and were difficult to teach. 
 
-Classic components are the largest remaining consumer of everything else we've been deprecating:
+Additionally, Classic components are the largest remaining consumer of everything else we've been deprecating or working to deprecate:
 
 - they extend `EmberObject`, requiring the [Classic Class system](https://github.com/emberjs/rfcs/pull/1117)
 - they are assembled out of [Mixins](https://github.com/emberjs/rfcs/pull/1116) (`Evented`, `ActionSupport`, `TargetActionSupport`, ...)

--- a/text/1216-deprecate-ember-component.md
+++ b/text/1216-deprecate-ember-component.md
@@ -426,33 +426,29 @@ Longer walkthroughs of the same migration:
 - the Ember Atlas recommended migration order (preserved in [Melanie Sumner's slides](https://noti.st/melsumner/Hl16PZ/slides)) -- source of "observers go before `@tracked`"
 - community walkthroughs from [Lighthouse](https://dev.to/lighthouse-intelligence/the-road-from-ember-classic-to-glimmer-components-4hlc) and [Isaac Lee](https://crunchingnumbers.live/2019/12/23/rewriting-apps-in-ember-octane/)
 
-Every step ships on its own, while the component is still classic. The numbering is a sensible default, not a dependency list. The only hard edges:
 
-- step 2 before steps 3 and 4 (the element has to exist in the template before things can attach to it)
-- everything before step 7 (the swap)
-
-1. **Get on native classes.**
+- **Get on native classes.**
     - codemod: [ember-native-class-codemod](https://github.com/ember-codemods/ember-native-class-codemod)
     - docs: [Native Classes upgrade guide](https://guides.emberjs.com/v5.12.0/upgrading/current-edition/native-classes/)
-2. **Flatten the element into the template**, then set `tagName = ''`.
+- **Flatten the element into the template**, then set `tagName = ''`.
     - codemod: [tagless-ember-components-codemod](https://github.com/ember-codemods/tagless-ember-components-codemod)
     - docs: [Glimmer Components upgrade guide](https://guides.emberjs.com/v5.12.0/upgrading/current-edition/glimmer-components/)
-3. **Replace event methods with `{{on}}`** on the element from step 2.
+- **Replace event methods with `{{on}}`** on the element from step 2.
     - docs: [`{{on}}` API](https://api.emberjs.com/ember/release/functions/@ember%2Fmodifier/on), [Actions, `{{on}}`, and `{{fn}}` upgrade guide](https://guides.emberjs.com/v5.12.0/upgrading/current-edition/action-on-and-fn/)
-4. **Move lifecycle hooks into modifiers.**
+- **Move lifecycle hooks into modifiers.**
     - docs: [Template Lifecycle, DOM, and Modifiers guide](https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifiers/), [ember-modifier](https://github.com/ember-modifier/ember-modifier)
     - optional intermediate: [@ember/render-modifiers](https://github.com/emberjs/ember-render-modifiers) -- a migration tool only, not recommended for applications (see its README); skippable entirely
-5. **Untangle two-way bindings**: take a callback argument instead.
+- **Untangle two-way bindings**: take a callback argument instead.
     - the only step that changes the component's public interface -- review carefully
     - docs: [Octane vs Classic cheat sheet](https://ember-learn.github.io/ember-octane-vs-classic-cheat-sheet/) (Data Down, Actions Up)
-6. **Replace `@computed` with getters.**
+- **Replace `@computed` with getters.**
     - observers first: they do not fire for `@tracked` updates, so remove them before anything they watch becomes tracked
     - docs: [Tracked Properties upgrade guide](https://guides.emberjs.com/v5.12.0/upgrading/current-edition/tracked-properties/)
-7. **Swap the superclass, and adopt `@tracked` in the same pass.**
+- **Swap the superclass, and adopt `@tracked` in the same pass.**
     - codemod for the `@tracked` part: [ember-tracked-properties-codemod](https://github.com/ember-codemods/ember-tracked-properties-codemod)
     - docs: [Glimmer Components upgrade guide](https://guides.emberjs.com/v5.12.0/upgrading/current-edition/glimmer-components/) covers the whole conversion (`this.args`, `constructor()`, ...)
     - go leaves-first: a computed property in a not-yet-converted parent cannot depend on this component's new native getters
-8. **(Optional) convert to `<template>`.**
+- **(Optional) convert to `<template>`.**
     - codemod: [@embroider/template-tag-codemod](https://github.com/embroider-build/embroider/tree/main/packages/template-tag-codemod) (requires colocation + native class syntax; works with classic components, so this is available any time after step 1)
     - docs: [Template Tag Format guide](https://guides.emberjs.com/release/components/template-tag-format/), [RFC #779](https://rfcs.emberjs.com/id/0779-first-class-component-templates)
 

--- a/text/1216-deprecate-ember-component.md
+++ b/text/1216-deprecate-ember-component.md
@@ -336,96 +336,78 @@ There is no equivalent -- angle bracket invocation has no positional arguments. 
 
 You do not need a flag day. Classic and Glimmer components coexist in the same app, the same route, even the same template -- migrate one component at a time, in any order.
 
-Here is the whole path in one picture. Diamonds ask "does your code do this?", rectangles are hand-work, double-walled boxes are codemods that do the work for you. The top section runs once across the whole app; the bottom section repeats for each component, top to bottom:
+Here is the whole path in one picture. Diamonds ask "does your code do this?" -- a "no" means there is nothing to do on that track. Rectangles are hand-work, double-walled boxes are codemods that do the work for you. Anything side-by-side is genuinely independent: do it in any order, or in parallel across a team. The only arrows that mean "must happen first" are the ones you see:
 
 ```mermaid
 flowchart TD
-    Start(["import Component from '@ember/component'"]) --> Colocated
+    Start(["import Component from '@ember/component'"])
 
-    subgraph once["once, app-wide"]
-        Colocated{"templates in app/templates/components/,<br>or layout / layoutName?"}
-        Migrator[["ember-component-template-colocation-migrator"]]
-        Curlies{"invoked curly-style: {{my-component}}?"}
-        Angle[["ember-angle-brackets-codemod"]]
-        Implicit{"bare {{foo}} in templates instead of<br>{{this.foo}} / {{@foo}}?"}
-        NoImplicit[["ember-no-implicit-this-codemod"]]
-        ClassicClass{"still using .extend()?"}
-        Mixins["deal with Mixins first: inline them, or<br>convert to class decorators (RFC #1116)"]
-        Native[["ember-native-class-codemod"]]
-
-        Colocated -->|yes| Migrator --> Curlies
-        Colocated -->|no| Curlies
-        Curlies -->|yes| Angle --> Implicit
-        Curlies -->|no| Implicit
-        Implicit -->|yes| NoImplicit --> ClassicClass
-        Implicit -->|no| ClassicClass
-        ClassicClass -->|"yes, with Mixins"| Mixins --> Native
+    subgraph once["once, app-wide -- these four are independent of each other"]
+        Colocated{"templates in app/templates/components/,<br>or layout / layoutName?"} -->|yes| Migrator[["ember-component-template-colocation-migrator"]]
+        Curlies{"invoked curly-style:<br>{{my-component}}?"} -->|yes| Angle[["ember-angle-brackets-codemod"]]
+        Implicit{"bare {{foo}} in templates instead of<br>{{this.foo}} / {{@foo}}?"} -->|yes| NoImplicit[["ember-no-implicit-this-codemod"]]
+        ClassicClass{"still using .extend()?"} -->|"yes, with Mixins"| Mixins["deal with Mixins first: inline them, or<br>convert to class decorators (RFC #1116)"]
+        Mixins --> Native[["ember-native-class-codemod"]]
         ClassicClass -->|yes| Native
     end
 
-    ClassicClass -->|no| Element
-    Native --> Element
+    Start --> once
+    once --> Hub["then, for each component (leaves first):<br>four tracks, no order between them --<br>work them in parallel if you like"]
 
-    subgraph each["per component, in order -- every step ships on its own, while still classic"]
-        Element{"tagName / classNames / classNameBindings /<br>attributeBindings / elementId / ariaRole?"}
-        Flatten["write the element in the template,<br>move the bindings onto it, add ...attributes,<br>set tagName = ''"]
-        Events{"click() / keyDown() / mouseEnter() / ...?"}
-        On["{{on}} on the element, in the template"]
-        Hooks{"didInsertElement / didUpdateAttrs /<br>willDestroyElement / didRender / this.element?"}
-        Mod["extract a modifier (ember-modifier);<br>@ember/render-modifiers as an intermediate"]
-        TwoWay{"this.set() on passed-in properties,<br>or callers reaching for {{mut}}?"}
-        Ddau["the caller keeps the state and<br>passes a callback down"]
-        Evented{"this.trigger() / this.on() from Evented?"}
-        Cb["plain functions / callbacks (see RFC #1111)"]
-        Derive{"didReceiveAttrs / observers / @computed<br>deriving data?"}
-        Getter["native getters; @cached if expensive"]
-        Local{"local mutable state via this.set()?"}
-        Tracked["@tracked + plain assignment<br>(ember-tracked-properties-codemod)"]
-        Actions{"actions hash / this.send()?"}
-        Methods["@action methods, called directly"]
-        Positional{"positionalParams?"}
-        Named["named arguments, at every call site"]
+    Hub --> el
+    Hub --> data
+    Hub --> derived
+    Hub --> inv
 
-        Element -->|yes| Flatten --> Events
-        Element -->|no| Events
-        Events -->|yes| On --> Hooks
-        Events -->|no| Hooks
-        Hooks -->|yes| Mod --> TwoWay
-        Hooks -->|no| TwoWay
-        TwoWay -->|yes| Ddau --> Evented
-        TwoWay -->|no| Evented
-        Evented -->|yes| Cb --> Derive
-        Evented -->|no| Derive
-        Derive -->|yes| Getter --> Local
-        Derive -->|no| Local
-        Local -->|yes| Tracked --> Actions
-        Local -->|no| Actions
-        Actions -->|yes| Methods --> Positional
-        Actions -->|no| Positional
-        Positional -->|yes| Named --> Swap
-        Positional -->|no| Swap
+    subgraph el["the element"]
+        Element{"anything on the wrapper element?<br>tagName / classNames / classNameBindings /<br>attributeBindings / elementId / ariaRole,<br>click()-style methods, this.element"} -->|yes| Flatten["write the element in the template,<br>move the bindings onto it, add ...attributes,<br>set tagName = ''"]
+        Flatten --> Events{"click() / keyDown() /<br>mouseEnter() / ...?"}
+        Events -->|yes| On["{{on}} on the element,<br>in the template"]
+        Flatten --> Hooks{"didInsertElement / didUpdateAttrs /<br>willDestroyElement / this.element?"}
+        Hooks -->|yes| Mod["extract a modifier (ember-modifier);<br>@ember/render-modifiers as an intermediate"]
     end
 
-    Swap["swap the superclass:<br>'@ember/component' → '@glimmer/component',<br>this.foo → this.args.foo ({{@foo}} in the template),<br>init() → constructor()"]
-    Gjs{"want template tag / gjs? (RFC #779)"}
-    TT[["@embroider/template-tag-codemod"]]
-    Done(["no more '@ember/component'"])
+    subgraph data["data flow"]
+        TwoWay{"this.set() on passed-in properties,<br>or callers reaching for {{mut}}?"} -->|yes| Ddau["the caller keeps the state and<br>passes a callback down"]
+        Evented{"this.trigger() / this.on()<br>from Evented?"} -->|yes| Cb["plain functions / callbacks<br>(see RFC #1111)"]
+    end
 
-    Swap --> Gjs
-    Gjs -->|yes| TT --> Done
-    Gjs -->|no| Done
+    subgraph derived["derived state"]
+        Observers{"observers?"} -->|yes| RmObs["remove them -- observers do not<br>fire for @tracked updates"]
+        RmObs --> Derive{"didReceiveAttrs / @computed<br>deriving data?"}
+        Observers -->|no| Derive
+        Derive -->|yes| Getter["native getters;<br>@cached if expensive"]
+    end
+
+    subgraph inv["invocation + actions"]
+        Actions{"actions hash /<br>this.send()?"} -->|yes| Methods["@action methods,<br>called directly"]
+        Positional{"positionalParams?"} -->|yes| Named["named arguments,<br>at every call site"]
+    end
+
+    el --> Swap
+    data --> Swap
+    derived --> Swap
+    inv --> Swap
+
+    Swap["one pass, per component: swap '@ember/component' → '@glimmer/component',<br>this.foo → this.args.foo ({{@foo}} in the template), init() → constructor(),<br>and local this.set() state → @tracked (ember-tracked-properties-codemod)"]
+    Swap --> Gjs{"want template tag / gjs?<br>(RFC #779)"}
+    Gjs -->|yes| TT[["@embroider/template-tag-codemod<br>(skips components that are not<br>colocated + native-class)"]]
+    TT --> Done
+    Gjs -->|no| Done(["no more '@ember/component'"])
 ```
 
-Within a single component, the trick is that almost every step above **works while the component is still classic**. That means each step is a small, shippable PR, and the scary-looking superclass swap is the _last_ and _smallest_ diff, not the first:
+"Leaves first" because computed properties cannot depend on native getters or tracked data without extra annotations -- so convert components that do not feed data into still-unconverted parents, and work your way up the tree. And `@tracked` rides along with the superclass swap rather than getting its own step: both require actually understanding the component's data flow, so pay that cost once. Both of these come straight from [LinkedIn's migration guides](https://github.com/chriskrycho/octane-migration-guides), which are the most battle-tested writeup of this migration -- they note their ordering exists to minimize how many times you touch each file, not because things break.
+
+Within a single component, the trick is that almost every step above **works while the component is still classic**. That means each step is a small, shippable PR, and the scary-looking superclass swap is the _last_ and _smallest_ diff, not the first. The numbering below is a sensible default, not a dependency list -- the only hard edges are that the element has to be in the template (step 2) before anything can attach to it (steps 3 and 4), and that everything classic-only has to be gone before the swap (step 7):
 
 1. **Get on native classes first.** If the component is still `Component.extend({ ... })`, run [ember-native-class-codemod](https://github.com/ember-codemods/ember-native-class-codemod). Everything below assumes native class syntax.
 2. **Flatten the element into the template.** Write the root element explicitly in the template, move `classNames` / `classNameBindings` / `attributeBindings` / `ariaRole` onto it, add `...attributes`, then set `tagName = ''`. Classic components fully support `tagName: ''` + splattributes, so this ships on its own.
 3. **Replace event methods with `{{on}}`.** Once the element is in the template, `click()` becomes `{{on "click" this.select}}` on that element. Also shippable while classic.
 4. **Move lifecycle hooks into modifiers.** [@ember/render-modifiers](https://github.com/emberjs/ember-render-modifiers) (`{{did-insert}}` / `{{did-update}}` / `{{will-destroy}}`) is the mechanical intermediate step; a purpose-built [ember-modifier](https://github.com/ember-modifier/ember-modifier) is the end state. Modifiers work on classic components' templates too.
 5. **Untangle two-way bindings.** Stop `this.set()`-ing anything that was passed in; take a callback argument instead. This is the only step that changes the component's public interface, so it's the one to review carefully.
-6. **Replace `@computed` with getters and local state with `@tracked`.** Tracked properties work inside classic components, so this also ships independently.
-7. **Swap the superclass.** `import Component from '@ember/component'` → `import Component from '@glimmer/component'`, and argument access moves from `this.foo` to `this.args.foo` (`{{@foo}}` in the template). Because of steps 2--6, there is nothing else left in the class that needs to change.
-8. **(Optional) convert to `<template>`.** See [RFC #779](https://rfcs.emberjs.com/id/0779-first-class-component-templates).
+6. **Replace `@computed` with getters.** Getters work inside classic components, so this also ships independently. If the component has observers, remove those first -- observers do not fire for `@tracked` updates, so they have to be gone before anything they watch becomes tracked.
+7. **Swap the superclass, and adopt `@tracked` in the same pass.** `import Component from '@ember/component'` → `import Component from '@glimmer/component'`, argument access moves from `this.foo` to `this.args.foo` (`{{@foo}}` in the template), `init()` becomes `constructor()`, and local mutable state becomes `@tracked` with plain assignment ([ember-tracked-properties-codemod](https://github.com/ember-codemods/ember-tracked-properties-codemod) handles the mechanical part). These travel together because both require understanding the component's data flow -- understand it once. Go leaves-first across the app, since a computed property in a not-yet-converted parent cannot depend on this component's new native getters. Because of steps 2--6, there is nothing else left in the class that needs to change.
+8. **(Optional) convert to `<template>`.** See [RFC #779](https://rfcs.emberjs.com/id/0779-first-class-component-templates). [@embroider/template-tag-codemod](https://github.com/embroider-build/embroider/tree/main/packages/template-tag-codemod) does this mechanically, and (deliberately) skips any component that is not yet colocated and on native class syntax.
 
 There is deliberately no single classic→glimmer codemod: steps 2, 4, and 5 involve decisions (where does `...attributes` go? what is the modifier's responsibility? who owns this state?) that a codemod would get wrong silently. The mechanical parts are covered:
 


### PR DESCRIPTION
<!-- If you are proposing a new RFC, please fill out the below template. 
If not, please remove the below contents
-->

# Propose deprecating "ember component"

<!-- Update the below to link to the rendered version of your RFC. 
The URL can be interpolated below or can be found by going to the files tab
and choosing `View file' from the `...' menu in the right hand corner of the file. -->

## Summary

This pull request is proposing a new RFC.

To succeed, it will need to pass into the [Exploring Stage](https://github.com/emberjs/rfcs#exploring), followed by the [Accepted Stage](https://github.com/emberjs/rfcs#accepted).

A Proposed or Exploring RFC may also move to the [Closed Stage](https://github.com/emberjs/rfcs#closed) if it is withdrawn by the author or if it is rejected by the Ember team. This requires an "FCP to Close" period.

**An FCP is required before merging this PR to advance to Accepted.**

Upon merging this PR, automation will open a draft PR for this RFC to move to the [Ready for Released Stage](https://github.com/emberjs/rfcs#ready-for-release).

<details>
  <summary>Exploring Stage Description</summary>

This stage is entered when the Ember team believes the concept described in the RFC should be pursued, but the RFC may still need some more work, discussion, answers to open questions, and/or a champion before it can move to the next stage.

An RFC is moved into Exploring with consensus of the relevant teams. The relevant team expects to spend time helping to refine the proposal. The RFC remains a PR and will have an `Exploring` label applied.

An Exploring RFC that is successfully completed can move to [Accepted](https://github.com/emberjs/rfcs#accepted) with an FCP is required as in the existing process. It may also be moved to [Closed](https://github.com/emberjs/rfcs#closed) with an FCP.
</details>

<details>
  <summary>Accepted Stage Description</summary>

To move into the "accepted stage" the RFC must have complete prose and have successfully passed through an "FCP to Accept" period in which the community has weighed in and consensus has been achieved on the direction. The relevant teams believe that the proposal is well-specified and ready for implementation. The RFC has a champion within one of the relevant teams.

If there are unanswered questions, we have outlined them and expect that they will be answered before [Ready for Release](https://github.com/emberjs/rfcs#ready-for-release). 

When the RFC is accepted, the PR will be merged, and automation will open a new PR to move the RFC to the [Ready for Release](https://github.com/emberjs/rfcs#ready-for-release) stage. That PR should be used to track implementation progress and gain consensus to move to the next stage.

</details>

## Checklist to move to Exploring

- [ ] The team believes the concepts described in the RFC should be pursued.
- [ ] The label `S-Proposed` is removed from the PR and the label `S-Exploring` is added. 
- [ ] The Ember team is willing to work on the proposal to get it to Accepted

## Checklist to move to Accepted

- [ ] This PR has had the `Final Comment Period` label has been added to start the FCP
- [ ] The RFC is announced in #news-and-announcements in the Ember Discord.
- [ ] The RFC has complete prose, is well-specified and ready for implementation.
  - [ ] All sections of the RFC are filled out.
  - [ ] Any unanswered questions are outlined and expected to be answered before Ready for Release.
  - [ ] "How we teach this?" is sufficiently filled out.
- [ ] The RFC has a champion within one of the relevant teams.
- [ ] The RFC has consensus after the FCP period.
